### PR TITLE
Add unified user responses endpoint

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -49,6 +49,8 @@ type application struct {
 	complaintRepo          *repositories.ComplaintRepository
 	serviceResponseHandler *handlers.ServiceResponseHandler
 	serviceResponseRepo    *repositories.ServiceResponseRepository
+	userResponsesHandler   *handlers.UserResponsesHandler
+	userResponsesRepo      *repositories.UserResponsesRepository
 	workHandler            *handlers.WorkHandler
 	workRepo               *repositories.WorkRepository
 	rentHandler            *handlers.RentHandler
@@ -108,6 +110,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	cityRepo := repositories.CityRepository{DB: db}
 	complaintRepo := repositories.ComplaintRepository{DB: db}
 	serviceResponseRepo := repositories.ServiceResponseRepository{DB: db}
+	userResponsesRepo := repositories.UserResponsesRepository{DB: db}
 	workRepo := repositories.WorkRepository{DB: db}
 	rentRepo := repositories.RentRepository{DB: db}
 	workReviewRepo := repositories.WorkReviewRepository{DB: db}
@@ -142,6 +145,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	cityService := services.CityService{CityRepo: &cityRepo}
 	complaintService := services.ComplaintService{ComplaintRepo: &complaintRepo}
 	serviceResponseService := &services.ServiceResponseService{ServiceResponseRepo: &serviceResponseRepo}
+	userResponsesService := &services.UserResponsesService{ResponsesRepo: &userResponsesRepo}
 	workService := &services.WorkService{WorkRepo: &workRepo}
 	rentService := &services.RentService{RentRepo: &rentRepo}
 	workReviewService := &services.WorkReviewService{WorkReviewsRepo: &workReviewRepo}
@@ -178,6 +182,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	cityHandler := handlers.CityHandler{Service: &cityService}
 	complaintHandler := &handlers.ComplaintHandler{Service: &complaintService}
 	serviceResponseHandler := &handlers.ServiceResponseHandler{Service: serviceResponseService}
+	userResponsesHandler := &handlers.UserResponsesHandler{Service: userResponsesService}
 	workHandler := &handlers.WorkHandler{Service: workService}
 	rentHandler := &handlers.RentHandler{Service: rentService}
 	workReviewHandler := &handlers.WorkReviewHandler{Service: workReviewService}
@@ -231,6 +236,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		db:                     db,
 		complaintHandler:       complaintHandler,
 		serviceResponseHandler: serviceResponseHandler,
+		userResponsesHandler:   userResponsesHandler,
 		workHandler:            workHandler,
 		rentHandler:            rentHandler,
 		workReviewHandler:      workReviewHandler,

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -147,6 +147,7 @@ func (app *application) routes() http.Handler {
 
 	// Service Response
 	mux.Post("/responses", authMiddleware.ThenFunc(app.serviceResponseHandler.CreateServiceResponse))
+	mux.Get("/responses/:user_id", standardMiddleware.ThenFunc(app.userResponsesHandler.GetResponsesByUserID))
 
 	// Work
 	mux.Post("/work", authMiddleware.ThenFunc(app.workHandler.CreateWork))

--- a/internal/handlers/user_responses_handler.go
+++ b/internal/handlers/user_responses_handler.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/services"
+)
+
+// UserResponsesHandler handles HTTP requests for user responses.
+type UserResponsesHandler struct {
+	Service *services.UserResponsesService
+}
+
+// GetResponsesByUserID returns all responses for the specified user.
+func (h *UserResponsesHandler) GetResponsesByUserID(w http.ResponseWriter, r *http.Request) {
+	userIDStr := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	responses, err := h.Service.GetResponsesByUserID(r.Context(), userID)
+	if err != nil {
+		http.Error(w, "failed to get responses", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(responses)
+}

--- a/internal/models/user_responses.go
+++ b/internal/models/user_responses.go
@@ -1,0 +1,24 @@
+package models
+
+import "time"
+
+// UserResponseItem represents a single response with the associated item details.
+type UserResponseItem struct {
+	ID            int       `json:"id"`
+	Name          string    `json:"name"`
+	Price         float64   `json:"price"`
+	Description   string    `json:"description"`
+	ResponsePrice float64   `json:"response_price"`
+	ResponseDate  time.Time `json:"response_date"`
+	Type          string    `json:"type"`
+}
+
+// UserResponses aggregates responses across different entity types.
+type UserResponses struct {
+	Service []UserResponseItem `json:"service"`
+	Ad      []UserResponseItem `json:"ad"`
+	Work    []UserResponseItem `json:"work"`
+	WorkAd  []UserResponseItem `json:"work_ad"`
+	Rent    []UserResponseItem `json:"rent"`
+	RentAd  []UserResponseItem `json:"rent_ad"`
+}

--- a/internal/repositories/user_responses_repository.go
+++ b/internal/repositories/user_responses_repository.go
@@ -1,0 +1,92 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+// UserResponsesRepository retrieves user responses across all entity types.
+type UserResponsesRepository struct {
+	DB *sql.DB
+}
+
+// GetResponsesByUserID returns all responses for a given user grouped by entity type.
+func (r *UserResponsesRepository) GetResponsesByUserID(ctx context.Context, userID int) (models.UserResponses, error) {
+	var result models.UserResponses
+
+	serviceQuery := `
+        SELECT s.id, s.name, s.price, s.description, sr.price, sr.created_at
+        FROM service_responses sr
+        JOIN service s ON s.id = sr.service_id
+        WHERE sr.user_id = ?`
+	if err := r.collect(ctx, &result.Service, serviceQuery, userID, "Service"); err != nil {
+		return result, err
+	}
+
+	adQuery := `
+        SELECT a.id, a.name, a.price, a.description, ar.price, ar.created_at
+        FROM ad_responses ar
+        JOIN ad a ON a.id = ar.ad_id
+        WHERE ar.user_id = ?`
+	if err := r.collect(ctx, &result.Ad, adQuery, userID, "Ad"); err != nil {
+		return result, err
+	}
+
+	workQuery := `
+        SELECT w.id, w.name, w.price, w.description, wr.price, wr.created_at
+        FROM work_responses wr
+        JOIN work w ON w.id = wr.work_id
+        WHERE wr.user_id = ?`
+	if err := r.collect(ctx, &result.Work, workQuery, userID, "Work"); err != nil {
+		return result, err
+	}
+
+	workAdQuery := `
+        SELECT wa.id, wa.name, wa.price, wa.description, war.price, war.created_at
+        FROM work_ad_responses war
+        JOIN work_ad wa ON wa.id = war.work_ad_id
+        WHERE war.user_id = ?`
+	if err := r.collect(ctx, &result.WorkAd, workAdQuery, userID, "Work Ad"); err != nil {
+		return result, err
+	}
+
+	rentQuery := `
+        SELECT r.id, r.name, r.price, r.description, rr.price, rr.created_at
+        FROM rent_responses rr
+        JOIN rent r ON r.id = rr.rent_id
+        WHERE rr.user_id = ?`
+	if err := r.collect(ctx, &result.Rent, rentQuery, userID, "Rent"); err != nil {
+		return result, err
+	}
+
+	rentAdQuery := `
+        SELECT ra.id, ra.name, ra.price, ra.description, rar.price, rar.created_at
+        FROM rent_ad_responses rar
+        JOIN rent_ad ra ON ra.id = rar.rent_ad_id
+        WHERE rar.user_id = ?`
+	if err := r.collect(ctx, &result.RentAd, rentAdQuery, userID, "Rent Ad"); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (r *UserResponsesRepository) collect(ctx context.Context, dest *[]models.UserResponseItem, query string, userID int, typ string) error {
+	rows, err := r.DB.QueryContext(ctx, query, userID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var item models.UserResponseItem
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.ResponsePrice, &item.ResponseDate); err != nil {
+			return err
+		}
+		item.Type = typ
+		*dest = append(*dest, item)
+	}
+	return rows.Err()
+}

--- a/internal/services/user_responses_service.go
+++ b/internal/services/user_responses_service.go
@@ -1,0 +1,18 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+// UserResponsesService provides business logic for retrieving user responses.
+type UserResponsesService struct {
+	ResponsesRepo *repositories.UserResponsesRepository
+}
+
+// GetResponsesByUserID fetches all responses made by a specific user.
+func (s *UserResponsesService) GetResponsesByUserID(ctx context.Context, userID int) (models.UserResponses, error) {
+	return s.ResponsesRepo.GetResponsesByUserID(ctx, userID)
+}


### PR DESCRIPTION
## Summary
- add models, repository, service and handler to aggregate responses by user across Service, Ad, Work, Work Ad, Rent and Rent Ad
- wire new handler into application initialization and routing

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895dc93533883248910f582ea12f55d