### PR TITLE
feat: add user avatar upload

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -33,9 +33,11 @@ func (app *application) routes() http.Handler {
 	mux.Post("/user/sign_in", standardMiddleware.ThenFunc(app.userHandler.SignIn))             //РАБОТАЕТ
 	mux.Post("/user/change_number", standardMiddleware.ThenFunc(app.userHandler.ChangeNumber)) //РАБОТАЕТ
 	mux.Post("/user/change_email", standardMiddleware.ThenFunc(app.userHandler.ChangeEmail))   //РАБОТАЕТ
-	mux.Put("/user/:id/city", authMiddleware.ThenFunc(app.userHandler.ChangeCityForUser))
-	mux.Get("/docs/:filename", authMiddleware.ThenFunc(app.userHandler.ServeProofDocument))
-	mux.Post("/user/:id/upgrade", authMiddleware.ThenFunc(app.userHandler.UpdateToWorker))
+        mux.Put("/user/:id/city", authMiddleware.ThenFunc(app.userHandler.ChangeCityForUser))
+        mux.Get("/docs/:filename", authMiddleware.ThenFunc(app.userHandler.ServeProofDocument))
+       mux.Post("/user/:id/avatar", authMiddleware.ThenFunc(app.userHandler.UploadAvatar))
+       mux.Get("/images/avatars/:filename", standardMiddleware.ThenFunc(app.userHandler.ServeAvatar))
+        mux.Post("/user/:id/upgrade", authMiddleware.ThenFunc(app.userHandler.UpdateToWorker))
 	mux.Post("/users/check_duplicate", standardMiddleware.ThenFunc(app.userHandler.CheckUserDuplicate))
 	mux.Post("/user/request_reset", authMiddleware.ThenFunc(app.userHandler.RequestPasswordReset))
 	mux.Post("/user/verify_reset_code", authMiddleware.ThenFunc(app.userHandler.VerifyResetCode))

--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -14,10 +14,11 @@ type Ad struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
-		ReviewRating float64 `json:"review_rating"`
-		ReviewsCount int     `json:"reviews_count"`
-	} `json:"user"`
+               Phone        string  `json:"phone"`
+               ReviewRating float64 `json:"review_rating"`
+               ReviewsCount int     `json:"reviews_count"`
+               AvatarPath   *string `json:"avatar_path,omitempty"`
+       } `json:"user"`
 	Images          []ImageAd  `json:"images"`
 	CategoryID      int        `json:"category_id, omitempty"`
 	SubcategoryID   int        `json:"subcategory_id, omitempty"`
@@ -71,9 +72,10 @@ type FilteredAd struct {
 	UserID           int     `json:"user_id"`
 	UserName         string  `json:"user_name"`
 	UserSurname      string  `json:"user_surname"`
-	UserPhone        string  `json:"user_phone"`
-	UserRating       float64 `json:"user_rating"`
-	UserReviewsCount int     `json:"user_reviews_count"`
+       UserPhone        string  `json:"user_phone"`
+       UserAvatarPath   *string `json:"user_avatar_path,omitempty"`
+       UserRating       float64 `json:"user_rating"`
+       UserReviewsCount int     `json:"user_reviews_count"`
 	AdID             int     `json:"ad_id"`
 	AdName           string  `json:"ad_name"`
 	AdPrice          float64 `json:"ad_price"`

--- a/internal/models/rent.go
+++ b/internal/models/rent.go
@@ -14,10 +14,11 @@ type Rent struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
-		ReviewRating float64 `json:"review_rating"`
-		ReviewsCount int     `json:"reviews_count"`
-	} `json:"user"`
+               Phone        string  `json:"phone"`
+               ReviewRating float64 `json:"review_rating"`
+               ReviewsCount int     `json:"reviews_count"`
+               AvatarPath   *string `json:"avatar_path,omitempty"`
+       } `json:"user"`
 	Images          []ImageRent `json:"images"`
 	CategoryID      int         `json:"category_id, omitempty"`
 	SubcategoryID   int         `json:"subcategory_id, omitempty"`
@@ -73,9 +74,10 @@ type FilteredRent struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
-	UserRating         float64 `json:"user_rating"`
-	UserReviewsCount   int     `json:"user_reviews_count"`
+       UserPhone          string  `json:"user_phone"`
+       UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
+       UserRating         float64 `json:"user_rating"`
+       UserReviewsCount   int     `json:"user_reviews_count"`
 	ServiceID          int     `json:"service_id"`
 	ServiceName        string  `json:"service_name"`
 	ServicePrice       float64 `json:"service_price"`

--- a/internal/models/rent_ad.go
+++ b/internal/models/rent_ad.go
@@ -14,10 +14,11 @@ type RentAd struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
-		ReviewRating float64 `json:"review_rating"`
-		ReviewsCount int     `json:"reviews_count"`
-	} `json:"user"`
+               Phone        string  `json:"phone"`
+               ReviewRating float64 `json:"review_rating"`
+               ReviewsCount int     `json:"reviews_count"`
+               AvatarPath   *string `json:"avatar_path,omitempty"`
+       } `json:"user"`
 	Images          []ImageRentAd `json:"images"`
 	CategoryID      int           `json:"category_id, omitempty"`
 	SubcategoryID   int           `json:"subcategory_id, omitempty"`
@@ -73,9 +74,10 @@ type FilteredRentAd struct {
 	UserID            int     `json:"user_id"`
 	UserName          string  `json:"user_name"`
 	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"user_phone"`
-	UserRating        float64 `json:"user_rating"`
-	UserReviewsCount  int     `json:"user_reviews_count"`
+       UserPhone         string  `json:"user_phone"`
+       UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
+       UserRating        float64 `json:"user_rating"`
+       UserReviewsCount  int     `json:"user_reviews_count"`
 	RentAdID          int     `json:"rentad_id"`
 	RentAdName        string  `json:"rentad_name"`
 	RentAdPrice       float64 `json:"rentad_price"`

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -14,10 +14,11 @@ type Service struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
-		ReviewRating float64 `json:"review_rating"`
-		ReviewsCount int     `json:"reviews_count"`
-	} `json:"user"`
+               Phone        string  `json:"phone"`
+               ReviewRating float64 `json:"review_rating"`
+               ReviewsCount int     `json:"reviews_count"`
+               AvatarPath   *string `json:"avatar_path,omitempty"`
+       } `json:"user"`
 	Images          []Image    `json:"images"`
 	CategoryID      int        `json:"category_id, omitempty"`
 	SubcategoryID   int        `json:"subcategory_id, omitempty"`
@@ -72,9 +73,10 @@ type FilteredService struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
-	UserRating         float64 `json:"user_rating"`
-	UserReviewsCount   int     `json:"user_reviews_count"`
+       UserPhone          string  `json:"user_phone"`
+       UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
+       UserRating         float64 `json:"user_rating"`
+       UserReviewsCount   int     `json:"user_reviews_count"`
 	ServiceID          int     `json:"service_id"`
 	ServiceName        string  `json:"service_name"`
 	ServicePrice       float64 `json:"service_price"`

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -15,9 +15,10 @@ type User struct {
 	Email        string     `json:"email"`
 	Password     string     `json:"password"`
 	CityID       *int       `json:"city_id,omitempty"`
-	YearsOfExp   *int       `json:"years_of_exp,omitempty"`
-	DocOfProof   *string    `json:"doc_of_proof,omitempty"`
-	ReviewRating float64    `json:"review_rating"`
+        YearsOfExp   *int       `json:"years_of_exp,omitempty"`
+        DocOfProof   *string    `json:"doc_of_proof,omitempty"`
+        AvatarPath   *string    `json:"avatar_path,omitempty"`
+        ReviewRating float64    `json:"review_rating"`
 	Role         string     `json:"role,omitempty"`
 	Latitude     *string    `json:"latitude,omitempty"`
 	Longitude    *string    `json:"longitude,omitempty"`

--- a/internal/models/work.go
+++ b/internal/models/work.go
@@ -14,10 +14,11 @@ type Work struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
-		ReviewRating float64 `json:"review_rating"`
-		ReviewsCount int     `json:"reviews_count"`
-	} `json:"user"`
+               Phone        string  `json:"phone"`
+               ReviewRating float64 `json:"review_rating"`
+               ReviewsCount int     `json:"reviews_count"`
+               AvatarPath   *string `json:"avatar_path,omitempty"`
+       } `json:"user"`
 	Images          []ImageWork `json:"images"`
 	CategoryID      int         `json:"category_id, omitempty"`
 	SubcategoryID   int         `json:"subcategory_id, omitempty"`
@@ -78,9 +79,10 @@ type FilteredWork struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
-	UserRating         float64 `json:"user_rating"`
-	UserReviewsCount   int     `json:"user_reviews_count"`
+       UserPhone          string  `json:"user_phone"`
+       UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
+       UserRating         float64 `json:"user_rating"`
+       UserReviewsCount   int     `json:"user_reviews_count"`
 	ServiceID          int     `json:"service_id"`
 	ServiceName        string  `json:"service_name"`
 	ServicePrice       float64 `json:"service_price"`

--- a/internal/models/work_ad.go
+++ b/internal/models/work_ad.go
@@ -14,10 +14,11 @@ type WorkAd struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
-		ReviewRating float64 `json:"review_rating"`
-		ReviewsCount int     `json:"reviews_count"`
-	} `json:"user"`
+               Phone        string  `json:"phone"`
+               ReviewRating float64 `json:"review_rating"`
+               ReviewsCount int     `json:"reviews_count"`
+               AvatarPath   *string `json:"avatar_path,omitempty"`
+       } `json:"user"`
 	Images          []ImageWorkAd `json:"images"`
 	CategoryID      int           `json:"category_id, omitempty"`
 	SubcategoryID   int           `json:"subcategory_id, omitempty"`
@@ -78,9 +79,10 @@ type FilteredWorkAd struct {
 	UserID            int     `json:"user_id"`
 	UserName          string  `json:"user_name"`
 	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"user_phone"`
-	UserRating        float64 `json:"user_rating"`
-	UserReviewsCount  int     `json:"user_reviews_count"`
+       UserPhone         string  `json:"user_phone"`
+       UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
+       UserRating        float64 `json:"user_rating"`
+       UserReviewsCount  int     `json:"user_reviews_count"`
 	WorkAdID          int     `json:"workad_id"`
 	WorkAdName        string  `json:"workad_name"`
 	WorkAdPrice       float64 `json:"workad_price"`

--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -62,7 +62,7 @@ func (r *AdRepository) CreateAd(ctx context.Context, ad models.Ad) (models.Ad, e
 func (r *AdRepository) GetAdByID(ctx context.Context, id int) (models.Ad, error) {
 	query := `
                SELECT s.id, s.name, s.address, s.price, s.user_id,
-                      u.id, u.name, u.surname, u.phone, u.review_rating,
+                      u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                       s.images, s.category_id, c.name, s.subcategory_id, sub.name,
                       s.description, s.avg_rating, s.top, s.liked, s.status, s.created_at, s.updated_at
                FROM ad s
@@ -76,7 +76,7 @@ func (r *AdRepository) GetAdByID(ctx context.Context, id int) (models.Ad, error)
 	var imagesJSON []byte
 	err := r.DB.QueryRowContext(ctx, query, id).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status,
 		&s.CreatedAt, &s.UpdatedAt,
 	)
@@ -154,7 +154,7 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, categor
 
 	baseQuery := `
                SELECT s.id, s.name, s.address, s.price, s.user_id,
-                      u.id, u.name, u.surname, u.phone, u.review_rating,
+                      u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                       s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top,
                       CASE WHEN sf.ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked,
                       s.status,  s.created_at, s.updated_at
@@ -234,7 +234,7 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, categor
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status,
 			&s.CreatedAt, &s.UpdatedAt,
 		)
@@ -266,7 +266,7 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, categor
 
 func (r *AdRepository) GetAdByUserID(ctx context.Context, userID int) ([]models.Ad, error) {
 	query := `
-		SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.review_rating, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.created_at, s.updated_at
+                SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.created_at, s.updated_at
 		FROM ad s
 		JOIN users u ON s.user_id = u.id
 		WHERE user_id = ?
@@ -283,7 +283,7 @@ func (r *AdRepository) GetAdByUserID(ctx context.Context, userID int) ([]models.
 		var s models.Ad
 		var imagesJSON []byte
 		if err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.ReviewRating, &imagesJSON,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
 			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.CreatedAt, &s.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -308,7 +308,7 @@ func (r *AdRepository) GetAdByUserID(ctx context.Context, userID int) ([]models.
 func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterAdRequest) ([]models.FilteredAd, error) {
 	query := `
                SELECT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description
                FROM ad s
                JOIN users u ON s.user_id = u.id
@@ -365,7 +365,7 @@ func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterA
 	for rows.Next() {
 		var s models.FilteredAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
 			&s.AdID, &s.AdName, &s.AdPrice, &s.AdDescription,
 		); err != nil {
 			return nil, err
@@ -382,12 +382,12 @@ func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterA
 
 func (r *AdRepository) FetchAdByStatusAndUserID(ctx context.Context, userID int, status string) ([]models.Ad, error) {
 	query := `
-	SELECT 
-		s.id, s.name, s.address, s.price, s.user_id,
-		u.id, u.name, u.review_rating,
-		s.images, s.category_id, s.subcategory_id, s.description,
-		s.avg_rating, s.top, s.liked, s.status,
-		s.created_at, s.updated_at
+        SELECT
+                s.id, s.name, s.address, s.price, s.user_id,
+                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                s.images, s.category_id, s.subcategory_id, s.description,
+                s.avg_rating, s.top, s.liked, s.status,
+                s.created_at, s.updated_at
 	FROM ad s
 	JOIN users u ON s.user_id = u.id
 	WHERE s.status = ? AND s.user_id = ?`
@@ -404,7 +404,7 @@ func (r *AdRepository) FetchAdByStatusAndUserID(ctx context.Context, userID int,
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.ReviewRating,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status,
 			&s.CreatedAt, &s.UpdatedAt,
@@ -425,7 +425,7 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 
 	query := `
                SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description,
                        CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
                FROM ad s
@@ -500,7 +500,7 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 	for rows.Next() {
 		var s models.FilteredAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
 			&s.AdID, &s.AdName, &s.AdPrice, &s.AdDescription, &s.Liked,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
@@ -526,7 +526,7 @@ func (r *AdRepository) GetAdByAdIDAndUserID(ctx context.Context, adID int, userI
 	query := `
                SELECT
                        s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -545,7 +545,7 @@ func (r *AdRepository) GetAdByAdIDAndUserID(ctx context.Context, adID int, userI
 
 	err := r.DB.QueryRowContext(ctx, query, userID, adID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -66,7 +66,7 @@ func (r *RentAdRepository) CreateRentAd(ctx context.Context, rent models.RentAd)
 
 func (r *RentAdRepository) GetRentAdByID(ctx context.Context, id int) (models.RentAd, error) {
 	query := `
-               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked, w.status, w.rent_type, w.deposit, w.latitude, w.longitude, w.created_at, w.updated_at
+               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked, w.status, w.rent_type, w.deposit, w.latitude, w.longitude, w.created_at, w.updated_at
                 FROM rent_ad w
                 JOIN users u ON w.user_id = u.id
                 JOIN rent_categories c ON w.category_id = c.id
@@ -77,7 +77,7 @@ func (r *RentAdRepository) GetRentAdByID(ctx context.Context, id int) (models.Re
 	var s models.RentAd
 	var imagesJSON []byte
 	err := r.DB.QueryRowContext(ctx, query, id).Scan(
-		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -154,7 +154,7 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 	)
 
 	baseQuery := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM rent_ad s
                LEFT JOIN rent_ad_favorites sf ON sf.rent_ad_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id
@@ -230,7 +230,7 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 		var s models.RentAd
 		var imagesJSON []byte
 		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
 		)
 		if err != nil {
@@ -260,7 +260,7 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 
 func (r *RentAdRepository) GetRentsAdByUserID(ctx context.Context, userID int) ([]models.RentAd, error) {
 	query := `
-		SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.review_rating, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+                SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
 		FROM rent_ad s
 		JOIN users u ON s.user_id = u.id
 		WHERE user_id = ?
@@ -277,7 +277,7 @@ func (r *RentAdRepository) GetRentsAdByUserID(ctx context.Context, userID int) (
 		var s models.RentAd
 		var imagesJSON []byte
 		if err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.ReviewRating, &imagesJSON,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
 			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -302,7 +302,7 @@ func (r *RentAdRepository) GetRentsAdByUserID(ctx context.Context, userID int) (
 func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req models.FilterRentAdRequest) ([]models.FilteredRentAd, error) {
 	query := `
                SELECT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description
                FROM rent_ad s
                JOIN users u ON s.user_id = u.id
@@ -359,7 +359,7 @@ func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req model
 	for rows.Next() {
 		var s models.FilteredRentAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
 			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription,
 		); err != nil {
 			return nil, err
@@ -376,12 +376,12 @@ func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req model
 
 func (r *RentAdRepository) FetchByStatusAndUserID(ctx context.Context, userID int, status string) ([]models.RentAd, error) {
 	query := `
-	SELECT 
-		s.id, s.name, s.address, s.price, s.user_id,
-		u.id, u.name, u.review_rating,
-		s.images, s.category_id, s.subcategory_id, s.description,
-		s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude,
-		s.created_at, s.updated_at
+        SELECT
+                s.id, s.name, s.address, s.price, s.user_id,
+                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                s.images, s.category_id, s.subcategory_id, s.description,
+                s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude,
+                s.created_at, s.updated_at
 	FROM rent_ad s
 	JOIN users u ON s.user_id = u.id
 	WHERE s.status = ? AND s.user_id = ?`
@@ -398,7 +398,7 @@ func (r *RentAdRepository) FetchByStatusAndUserID(ctx context.Context, userID in
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.ReviewRating,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt,
 			&s.UpdatedAt,
@@ -419,7 +419,7 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 
 	query := `
                SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description,
                        CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
                FROM rent_ad s
@@ -494,7 +494,7 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 	for rows.Next() {
 		var s models.FilteredRentAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
 			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription, &s.Liked,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
@@ -520,7 +520,7 @@ func (r *RentAdRepository) GetRentAdByRentIDAndUserID(ctx context.Context, rentA
 	query := `
                SELECT
                        s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -539,7 +539,7 @@ func (r *RentAdRepository) GetRentAdByRentIDAndUserID(ctx context.Context, rentA
 
 	err := r.DB.QueryRowContext(ctx, query, userID, rentAdID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -65,8 +65,8 @@ func (r *RentRepository) CreateRent(ctx context.Context, rent models.Rent) (mode
 }
 
 func (r *RentRepository) GetRentByID(ctx context.Context, id int) (models.Rent, error) {
-	query := `
-               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked, w.status, w.rent_type, w.deposit, w.latitude, w.longitude, w.created_at, w.updated_at
+       query := `
+               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked, w.status, w.rent_type, w.deposit, w.latitude, w.longitude, w.created_at, w.updated_at
                 FROM rent w
                 JOIN users u ON w.user_id = u.id
                 JOIN rent_categories c ON w.category_id = c.id
@@ -76,11 +76,11 @@ func (r *RentRepository) GetRentByID(ctx context.Context, id int) (models.Rent, 
 
 	var s models.Rent
 	var imagesJSON []byte
-	err := r.DB.QueryRowContext(ctx, query, id).Scan(
-		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
-		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt,
-		&s.UpdatedAt,
-	)
+       err := r.DB.QueryRowContext(ctx, query, id).Scan(
+               &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+               &imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt,
+               &s.UpdatedAt,
+       )
 
 	if err == sql.ErrNoRows {
 		return models.Rent{}, errors.New("not found")
@@ -153,8 +153,8 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ca
 		conditions []string
 	)
 
-	baseQuery := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+       baseQuery := `
+               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM rent s
                LEFT JOIN rent_favorites sf ON sf.rent_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id
@@ -229,10 +229,10 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ca
 	for rows.Next() {
 		var s models.Rent
 		var imagesJSON []byte
-		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
-			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
-		)
+               err := rows.Scan(
+                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+                        &imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
+                )
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("scan error: %w", err)
 		}
@@ -259,12 +259,12 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ca
 }
 
 func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]models.Rent, error) {
-	query := `
-		SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.review_rating, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
-		FROM rent s
-		JOIN users u ON s.user_id = u.id
-		WHERE user_id = ?
-	`
+       query := `
+                SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+                FROM rent s
+                JOIN users u ON s.user_id = u.id
+                WHERE user_id = ?
+       `
 
 	rows, err := r.DB.QueryContext(ctx, query, userID)
 	if err != nil {
@@ -276,10 +276,10 @@ func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]mo
 	for rows.Next() {
 		var s models.Rent
 		var imagesJSON []byte
-		if err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.ReviewRating, &imagesJSON,
-			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
-		); err != nil {
+               if err := rows.Scan(
+                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
+                        &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
+                ); err != nil {
 			return nil, err
 		}
 
@@ -300,9 +300,9 @@ func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]mo
 }
 
 func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.FilterRentRequest) ([]models.FilteredRent, error) {
-	query := `
+       query := `
                SELECT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description
                FROM rent s
                JOIN users u ON s.user_id = u.id
@@ -358,12 +358,12 @@ func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.Fi
 	var rents []models.FilteredRent
 	for rows.Next() {
 		var s models.FilteredRent
-		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
-		); err != nil {
-			return nil, err
-		}
+               if err := rows.Scan(
+                        &s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+                        &s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
+                ); err != nil {
+                       return nil, err
+               }
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.UserReviewsCount = count
@@ -375,16 +375,16 @@ func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.Fi
 }
 
 func (r *RentRepository) FetchByStatusAndUserID(ctx context.Context, userID int, status string) ([]models.Rent, error) {
-	query := `
-	SELECT 
-		s.id, s.name, s.address, s.price, s.user_id,
-		u.id, u.name, u.review_rating,
-		s.images, s.category_id, s.subcategory_id, s.description,
-		s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude,
-		s.created_at, s.updated_at
-	FROM rent s
-	JOIN users u ON s.user_id = u.id
-	WHERE s.status = ? AND s.user_id = ?`
+       query := `
+        SELECT
+                s.id, s.name, s.address, s.price, s.user_id,
+                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                s.images, s.category_id, s.subcategory_id, s.description,
+                s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude,
+                s.created_at, s.updated_at
+        FROM rent s
+        JOIN users u ON s.user_id = u.id
+        WHERE s.status = ? AND s.user_id = ?`
 
 	rows, err := r.DB.QueryContext(ctx, query, status, userID)
 	if err != nil {
@@ -396,13 +396,13 @@ func (r *RentRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 	for rows.Next() {
 		var s models.Rent
 		var imagesJSON []byte
-		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.ReviewRating,
-			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
-			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt,
-			&s.UpdatedAt,
-		)
+               err := rows.Scan(
+                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
+                        &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+                        &imagesJSON, &s.CategoryID, &s.SubcategoryID,
+                        &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt,
+                        &s.UpdatedAt,
+                )
 		if err != nil {
 			return nil, fmt.Errorf("scan error: %w", err)
 		}
@@ -417,9 +417,9 @@ func (r *RentRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req models.FilterRentRequest, userID int) ([]models.FilteredRent, error) {
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
-	query := `
+       query := `
                SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description,
                        CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
                FROM rent s
@@ -493,13 +493,13 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 	var rents []models.FilteredRent
 	for rows.Next() {
 		var s models.FilteredRent
-		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked,
-		); err != nil {
-			log.Printf("[ERROR] Failed to scan row: %v", err)
-			return nil, fmt.Errorf("failed to scan row: %w", err)
-		}
+               if err := rows.Scan(
+                        &s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+                        &s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked,
+                ); err != nil {
+                       log.Printf("[ERROR] Failed to scan row: %v", err)
+                       return nil, fmt.Errorf("failed to scan row: %w", err)
+               }
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.UserReviewsCount = count
@@ -520,7 +520,7 @@ func (r *RentRepository) GetRentByRentIDAndUserID(ctx context.Context, rentID in
 	query := `
                SELECT
                        s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -537,10 +537,10 @@ func (r *RentRepository) GetRentByRentIDAndUserID(ctx context.Context, rentID in
 	var s models.Rent
 	var imagesJSON []byte
 
-	err := r.DB.QueryRowContext(ctx, query, userID, rentID).Scan(
-		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
-		&imagesJSON, &s.CategoryID, &s.CategoryName,
+       err := r.DB.QueryRowContext(ctx, query, userID, rentID).Scan(
+               &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
+               &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+               &imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,
 		&s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,

--- a/internal/repositories/user_repo.go
+++ b/internal/repositories/user_repo.go
@@ -51,15 +51,15 @@ func (r *UserRepository) GetUserByID(ctx context.Context, userID int) (models.Us
 	var user models.User
 
 	// Получаем основную информацию о пользователе
-	query := `SELECT id, name, surname, phone, email, password, city_id, role,
-		years_of_exp, skills, doc_of_proof, created_at, updated_at
-		FROM users WHERE id = ?`
+       query := `SELECT id, name, surname, phone, email, password, city_id, role,
+               years_of_exp, skills, doc_of_proof, avatar_path, created_at, updated_at
+               FROM users WHERE id = ?`
 
 	err := r.DB.QueryRowContext(ctx, query, userID).Scan(
 		&user.ID, &user.Name, &user.Surname, &user.Phone, &user.Email, &user.Password,
-		&user.CityID, &user.Role, &user.YearsOfExp, &user.Skills, &user.DocOfProof,
-		&user.CreatedAt, &user.UpdatedAt,
-	)
+               &user.CityID, &user.Role, &user.YearsOfExp, &user.Skills, &user.DocOfProof, &user.AvatarPath,
+               &user.CreatedAt, &user.UpdatedAt,
+       )
 	if err != nil {
 		return models.User{}, err
 	}
@@ -129,14 +129,18 @@ func (r *UserRepository) UpdateUser(ctx context.Context, user models.User) (mode
 		setParts = append(setParts, "years_of_exp = ?")
 		args = append(args, user.YearsOfExp)
 	}
-	if user.DocOfProof != nil {
-		setParts = append(setParts, "doc_of_proof = ?")
-		args = append(args, user.DocOfProof)
-	}
-	if user.ReviewRating != 0 {
-		setParts = append(setParts, "review_rating = ?")
-		args = append(args, user.ReviewRating)
-	}
+        if user.DocOfProof != nil {
+                setParts = append(setParts, "doc_of_proof = ?")
+                args = append(args, user.DocOfProof)
+        }
+       if user.AvatarPath != nil {
+               setParts = append(setParts, "avatar_path = ?")
+               args = append(args, user.AvatarPath)
+       }
+        if user.ReviewRating != 0 {
+                setParts = append(setParts, "review_rating = ?")
+                args = append(args, user.ReviewRating)
+        }
 	if user.Role != "" {
 		setParts = append(setParts, "role = ?")
 		args = append(args, user.Role)
@@ -195,14 +199,14 @@ func (r *UserRepository) DeleteUser(ctx context.Context, id int) error {
 func (r *UserRepository) GetUserByPhone(ctx context.Context, phone string) (models.User, error) {
 	var user models.User
 	query := `
-        SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, review_rating, role, latitude, longitude, created_at, updated_at
+       SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, avatar_path, review_rating, role, latitude, longitude, created_at, updated_at
         FROM users
         WHERE phone = ?
     `
 	err := r.DB.QueryRowContext(ctx, query, phone).Scan(
 		&user.ID, &user.Name, &user.Surname, &user.Middlename, &user.Phone, &user.Email, &user.Password, &user.CityID,
-		&user.YearsOfExp, &user.DocOfProof, &user.ReviewRating, &user.Role,
-		&user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
+               &user.YearsOfExp, &user.DocOfProof, &user.AvatarPath, &user.ReviewRating, &user.Role,
+               &user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
 	)
 	if err == sql.ErrNoRows {
 		return models.User{}, ErrUserNotFound
@@ -215,7 +219,7 @@ func (r *UserRepository) GetUserByPhone(ctx context.Context, phone string) (mode
 
 func (r *UserRepository) GetUsersByRole(ctx context.Context, role string) ([]models.User, error) {
 	query := `
-        SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, review_rating, role, latitude, longitude, created_at, updated_at
+       SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, avatar_path, review_rating, role, latitude, longitude, created_at, updated_at
         FROM users
         WHERE role = ?
     `
@@ -230,8 +234,8 @@ func (r *UserRepository) GetUsersByRole(ctx context.Context, role string) ([]mod
 		var user models.User
 		err := rows.Scan(
 			&user.ID, &user.Name, &user.Surname, &user.Middlename, &user.Phone, &user.Email, &user.Password, &user.CityID,
-			&user.YearsOfExp, &user.DocOfProof, &user.ReviewRating, &user.Role,
-			&user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
+                       &user.YearsOfExp, &user.DocOfProof, &user.AvatarPath, &user.ReviewRating, &user.Role,
+                       &user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
 		)
 		if err != nil {
 			return nil, err
@@ -249,7 +253,7 @@ func (r *UserRepository) GetUsersByRole(ctx context.Context, role string) ([]mod
 
 func (r *UserRepository) GetAllUsers(ctx context.Context) ([]models.User, error) {
 	query := `
-        SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, review_rating, role, latitude, longitude, created_at, updated_at
+       SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, avatar_path, review_rating, role, latitude, longitude, created_at, updated_at
         FROM users
     `
 	rows, err := r.DB.QueryContext(ctx, query)
@@ -263,8 +267,8 @@ func (r *UserRepository) GetAllUsers(ctx context.Context) ([]models.User, error)
 		var user models.User
 		err := rows.Scan(
 			&user.ID, &user.Name, &user.Surname, &user.Middlename, &user.Phone, &user.Email, &user.Password, &user.CityID,
-			&user.YearsOfExp, &user.DocOfProof, &user.ReviewRating, &user.Role,
-			&user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
+                       &user.YearsOfExp, &user.DocOfProof, &user.AvatarPath, &user.ReviewRating, &user.Role,
+                       &user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
 		)
 		if err != nil {
 			return nil, err
@@ -324,14 +328,14 @@ func (r *UserRepository) GetSession(ctx context.Context, id string) (models.Sess
 func (r *UserRepository) GetUserByEmail(ctx context.Context, email string) (models.User, error) {
 	var user models.User
 	query := `
-        SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, review_rating, role, latitude, longitude, created_at, updated_at
+       SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, avatar_path, review_rating, role, latitude, longitude, created_at, updated_at
         FROM users
         WHERE email = ?
     `
 	err := r.DB.QueryRowContext(ctx, query, email).Scan(
 		&user.ID, &user.Name, &user.Surname, &user.Middlename, &user.Phone, &user.Email, &user.Password, &user.CityID,
-		&user.YearsOfExp, &user.DocOfProof, &user.ReviewRating, &user.Role,
-		&user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
+               &user.YearsOfExp, &user.DocOfProof, &user.AvatarPath, &user.ReviewRating, &user.Role,
+               &user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -363,14 +367,14 @@ func (r *UserRepository) UpdatePassword(ctx context.Context, userID int, newPass
 func (r *UserRepository) GetUserByPhone1(ctx context.Context, phone string) (models.User, error) {
 	var user models.User
 	query := `
-        SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, review_rating, role, latitude, longitude, created_at, updated_at
+       SELECT id, name, surname, middlename, phone, email, password, city_id, years_of_exp, doc_of_proof, avatar_path, review_rating, role, latitude, longitude, created_at, updated_at
         FROM users
         WHERE phone = ?
     `
 	err := r.DB.QueryRowContext(ctx, query, phone).Scan(
 		&user.ID, &user.Name, &user.Surname, &user.Middlename, &user.Phone, &user.Email, &user.Password, &user.CityID,
-		&user.YearsOfExp, &user.DocOfProof, &user.ReviewRating, &user.Role,
-		&user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
+               &user.YearsOfExp, &user.DocOfProof, &user.AvatarPath, &user.ReviewRating, &user.Role,
+               &user.Latitude, &user.Longitude, &user.CreatedAt, &user.UpdatedAt,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
@@ -378,7 +382,15 @@ func (r *UserRepository) GetUserByPhone1(ctx context.Context, phone string) (mod
 		}
 		return models.User{}, err
 	}
-	return user, nil
+        return user, nil
+}
+
+func (r *UserRepository) UpdateUserAvatar(ctx context.Context, userID int, avatarPath string) (models.User, error) {
+       query := `UPDATE users SET avatar_path = ?, updated_at = NOW() WHERE id = ?`
+       if _, err := r.DB.ExecContext(ctx, query, avatarPath, userID); err != nil {
+               return models.User{}, err
+       }
+       return r.GetUserByID(ctx, userID)
 }
 
 func (r *UserRepository) ChangeCityForUser(ctx context.Context, userID int, cityID int) error {

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -69,7 +69,7 @@ func (r *WorkAdRepository) CreateWorkAd(ctx context.Context, work models.WorkAd)
 
 func (r *WorkAdRepository) GetWorkAdByID(ctx context.Context, id int) (models.WorkAd, error) {
 	query := `
-               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked, w.status, w.work_experience, w.city_id, city.name, city.type, w.schedule, w.distance_work, w.payment_period, w.latitude, w.longitude, w.created_at, w.updated_at
+               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked, w.status, w.work_experience, w.city_id, city.name, city.type, w.schedule, w.distance_work, w.payment_period, w.latitude, w.longitude, w.created_at, w.updated_at
                 FROM work_ad w
                 JOIN users u ON w.user_id = u.id
                 JOIN work_categories c ON w.category_id = c.id
@@ -81,7 +81,7 @@ func (r *WorkAdRepository) GetWorkAdByID(ctx context.Context, id int) (models.Wo
 	var s models.WorkAd
 	var imagesJSON []byte
 	err := r.DB.QueryRowContext(ctx, query, id).Scan(
-		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.CityType, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -158,7 +158,7 @@ func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int
 	)
 
 	baseQuery := `
-       SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.work_ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+       SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.work_ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM work_ad s
                LEFT JOIN work_ad_favorites sf ON sf.work_ad_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id
@@ -234,7 +234,7 @@ func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int
 		var s models.WorkAd
 		var imagesJSON []byte
 		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 			&s.UpdatedAt,
 		)
@@ -265,7 +265,7 @@ func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int
 
 func (r *WorkAdRepository) GetWorksAdByUserID(ctx context.Context, userID int) ([]models.WorkAd, error) {
 	query := `
-		SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.review_rating, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+                SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
 		FROM work_ad s
 		JOIN users u ON s.user_id = u.id
 		WHERE user_id = ?
@@ -282,7 +282,7 @@ func (r *WorkAdRepository) GetWorksAdByUserID(ctx context.Context, userID int) (
 		var s models.WorkAd
 		var imagesJSON []byte
 		if err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.ReviewRating, &imagesJSON,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
 			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 			&s.UpdatedAt,
 		); err != nil {
@@ -308,7 +308,7 @@ func (r *WorkAdRepository) GetWorksAdByUserID(ctx context.Context, userID int) (
 func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req models.FilterWorkAdRequest) ([]models.FilteredWorkAd, error) {
 	query := `
                SELECT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description
                FROM work_ad s
                JOIN users u ON s.user_id = u.id
@@ -365,7 +365,7 @@ func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req model
 	for rows.Next() {
 		var s models.FilteredWorkAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
 			&s.WorkAdID, &s.WorkAdName, &s.WorkAdPrice, &s.WorkAdDescription,
 		); err != nil {
 			return nil, err
@@ -382,12 +382,12 @@ func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req model
 
 func (r *WorkAdRepository) FetchByStatusAndUserID(ctx context.Context, userID int, status string) ([]models.WorkAd, error) {
 	query := `
-	SELECT 
-		s.id, s.name, s.address, s.price, s.user_id,
-		u.id, u.name, u.review_rating,
-		s.images, s.category_id, s.subcategory_id, s.description,
-		s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude,
-		s.created_at, s.updated_at
+        SELECT
+                s.id, s.name, s.address, s.price, s.user_id,
+                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                s.images, s.category_id, s.subcategory_id, s.description,
+                s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude,
+                s.created_at, s.updated_at
 	FROM work_ad s
 	JOIN users u ON s.user_id = u.id
 	WHERE s.status = ? AND s.user_id = ?`
@@ -404,7 +404,7 @@ func (r *WorkAdRepository) FetchByStatusAndUserID(ctx context.Context, userID in
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.ReviewRating,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude,
 			&s.CreatedAt, &s.UpdatedAt,
@@ -425,7 +425,7 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
 
 	query := `
                SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description,
                        CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
                FROM work_ad s
@@ -500,7 +500,7 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
 	for rows.Next() {
 		var s models.FilteredWorkAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
 			&s.WorkAdID, &s.WorkAdName, &s.WorkAdPrice, &s.WorkAdDescription, &s.Liked,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
@@ -526,7 +526,7 @@ func (r *WorkAdRepository) GetWorkAdByWorkIDAndUserID(ctx context.Context, worka
 	query := `
                SELECT
                        s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -546,7 +546,7 @@ func (r *WorkAdRepository) GetWorkAdByWorkIDAndUserID(ctx context.Context, worka
 
 	err := r.DB.QueryRowContext(ctx, query, userID, workadID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -70,7 +70,7 @@ func (r *WorkRepository) CreateWork(ctx context.Context, work models.Work) (mode
 func (r *WorkRepository) GetWorkByID(ctx context.Context, id int) (models.Work, error) {
 	query := `
               SELECT w.id, w.name, w.address, w.price, w.user_id,
-                     u.id, u.name, u.surname, u.phone, u.review_rating,
+                     u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                      w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked, w.status, w.work_experience, w.city_id, city.name, city.type, w.schedule, w.distance_work, w.payment_period, w.latitude, w.longitude, w.created_at, w.updated_at
                FROM work w
                JOIN users u ON w.user_id = u.id
@@ -84,7 +84,7 @@ func (r *WorkRepository) GetWorkByID(ctx context.Context, id int) (models.Work, 
 	var imagesJSON []byte
 	err := r.DB.QueryRowContext(ctx, query, id).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
+               &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.CityType, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -162,7 +162,7 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ca
 
 	baseQuery := `
                SELECT s.id, s.name, s.address, s.price, s.user_id,
-                      u.id, u.name, u.surname, u.phone, u.review_rating,
+                      u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                       s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top,
                       CASE WHEN sf.work_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked,
                       s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
@@ -240,12 +240,12 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ca
 	for rows.Next() {
 		var s models.Work
 		var imagesJSON []byte
-		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
-			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
-			&s.UpdatedAt,
-		)
+               err := rows.Scan(
+                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
+                        &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+                        &imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
+                        &s.UpdatedAt,
+                )
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("scan error: %w", err)
 		}
@@ -273,12 +273,12 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ca
 }
 
 func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]models.Work, error) {
-	query := `
-		SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.review_rating, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
-		FROM work s
-		JOIN users u ON s.user_id = u.id
-		WHERE user_id = ?
-	`
+       query := `
+                SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+                FROM work s
+                JOIN users u ON s.user_id = u.id
+                WHERE user_id = ?
+       `
 
 	rows, err := r.DB.QueryContext(ctx, query, userID)
 	if err != nil {
@@ -290,11 +290,11 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 	for rows.Next() {
 		var s models.Work
 		var imagesJSON []byte
-		if err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.ReviewRating, &imagesJSON,
-			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
-			&s.UpdatedAt,
-		); err != nil {
+               if err := rows.Scan(
+                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
+                        &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
+                        &s.UpdatedAt,
+                ); err != nil {
 			return nil, err
 		}
 
@@ -317,7 +317,7 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.FilterWorkRequest) ([]models.FilteredWork, error) {
 	query := `
                SELECT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description
                FROM work s
                JOIN users u ON s.user_id = u.id
@@ -373,12 +373,12 @@ func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.Fi
 	var works []models.FilteredWork
 	for rows.Next() {
 		var s models.FilteredWork
-		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
-		); err != nil {
-			return nil, err
-		}
+               if err := rows.Scan(
+                        &s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+                        &s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
+                ); err != nil {
+                       return nil, err
+               }
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.UserReviewsCount = count
@@ -390,16 +390,16 @@ func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.Fi
 }
 
 func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int, status string) ([]models.Work, error) {
-	query := `
-	SELECT 
-		s.id, s.name, s.address, s.price, s.user_id,
-		u.id, u.name, u.review_rating,
-		s.images, s.category_id, s.subcategory_id, s.description,
-		s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude,
-		s.created_at, s.updated_at
-	FROM work s
-	JOIN users u ON s.user_id = u.id
-	WHERE s.status = ? AND s.user_id = ?`
+       query := `
+        SELECT
+                s.id, s.name, s.address, s.price, s.user_id,
+                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                s.images, s.category_id, s.subcategory_id, s.description,
+                s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude,
+                s.created_at, s.updated_at
+        FROM work s
+        JOIN users u ON s.user_id = u.id
+        WHERE s.status = ? AND s.user_id = ?`
 
 	rows, err := r.DB.QueryContext(ctx, query, status, userID)
 	if err != nil {
@@ -411,13 +411,13 @@ func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 	for rows.Next() {
 		var s models.Work
 		var imagesJSON []byte
-		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.ReviewRating,
-			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
-			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude,
-			&s.CreatedAt, &s.UpdatedAt,
-		)
+               err := rows.Scan(
+                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
+                        &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+                        &imagesJSON, &s.CategoryID, &s.SubcategoryID,
+                        &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude,
+                        &s.CreatedAt, &s.UpdatedAt,
+                )
 		if err != nil {
 			return nil, fmt.Errorf("scan error: %w", err)
 		}
@@ -432,9 +432,9 @@ func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req models.FilterWorkRequest, userID int) ([]models.FilteredWork, error) {
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
-	query := `
+       query := `
                SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description,
                        CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
                FROM work s
@@ -508,13 +508,13 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 	var works []models.FilteredWork
 	for rows.Next() {
 		var s models.FilteredWork
-		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked,
-		); err != nil {
-			log.Printf("[ERROR] Failed to scan row: %v", err)
-			return nil, fmt.Errorf("failed to scan row: %w", err)
-		}
+               if err := rows.Scan(
+                        &s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+                        &s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked,
+                ); err != nil {
+                       log.Printf("[ERROR] Failed to scan row: %v", err)
+                       return nil, fmt.Errorf("failed to scan row: %w", err)
+               }
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.UserReviewsCount = count
@@ -535,7 +535,7 @@ func (r *WorkRepository) GetWorkByWorkIDAndUserID(ctx context.Context, workID in
 	query := `
                SELECT
                        s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating,
+                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -553,10 +553,10 @@ func (r *WorkRepository) GetWorkByWorkIDAndUserID(ctx context.Context, workID in
 	var s models.Work
 	var imagesJSON []byte
 
-	err := r.DB.QueryRowContext(ctx, query, userID, workID).Scan(
-		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating,
-		&imagesJSON, &s.CategoryID, &s.CategoryName,
+       err := r.DB.QueryRowContext(ctx, query, userID, workID).Scan(
+               &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
+               &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+               &imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,
 		&s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.CityType, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -242,7 +242,11 @@ func (s *UserService) UpdateUser(ctx context.Context, user models.User) (models.
 	if existingUser2.Phone != "" {
 		return models.User{}, errors.New("user with this phone already exists")
 	}
-	return s.UserRepo.UpdateUser(ctx, user)
+        return s.UserRepo.UpdateUser(ctx, user)
+}
+
+func (s *UserService) UpdateUserAvatar(ctx context.Context, userID int, avatarPath string) (models.User, error) {
+       return s.UserRepo.UpdateUserAvatar(ctx, userID, avatarPath)
 }
 
 func (s *UserService) DeleteUser(ctx context.Context, id int) error {


### PR DESCRIPTION
## Summary
- support avatar_path for users and related models
- add API to upload and serve user avatar images
- expose avatar data in user-related queries, including ads, rent ads, and work ads

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6897b92a3d4083248029910a4db74fca