### PR TITLE
Add endpoint to fetch user info from token

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -26,6 +26,7 @@ func (app *application) routes() http.Handler {
 	// Users
 	mux.Post("/user", adminAuthMiddleware.ThenFunc(app.userHandler.CreateUser))                //
 	mux.Get("/user", authMiddleware.ThenFunc(app.userHandler.GetUsers))                        //РАБОТАЕТ
+	mux.Get("/user/token", authMiddleware.ThenFunc(app.userHandler.GetUserByToken))            //РАБОТАЕТ
 	mux.Get("/user/:id", authMiddleware.ThenFunc(app.userHandler.GetUserByID))                 //РАБОТАЕТ
 	mux.Put("/user/:id", authMiddleware.ThenFunc(app.userHandler.UpdateUser))                  //РАБОТАЕТ
 	mux.Del("/user/:id", authMiddleware.ThenFunc(app.userHandler.DeleteUser))                  //ИСПРАВИТЬ
@@ -33,11 +34,11 @@ func (app *application) routes() http.Handler {
 	mux.Post("/user/sign_in", standardMiddleware.ThenFunc(app.userHandler.SignIn))             //РАБОТАЕТ
 	mux.Post("/user/change_number", standardMiddleware.ThenFunc(app.userHandler.ChangeNumber)) //РАБОТАЕТ
 	mux.Post("/user/change_email", standardMiddleware.ThenFunc(app.userHandler.ChangeEmail))   //РАБОТАЕТ
-        mux.Put("/user/:id/city", authMiddleware.ThenFunc(app.userHandler.ChangeCityForUser))
-        mux.Get("/docs/:filename", authMiddleware.ThenFunc(app.userHandler.ServeProofDocument))
-       mux.Post("/user/:id/avatar", authMiddleware.ThenFunc(app.userHandler.UploadAvatar))
-       mux.Get("/images/avatars/:filename", standardMiddleware.ThenFunc(app.userHandler.ServeAvatar))
-        mux.Post("/user/:id/upgrade", authMiddleware.ThenFunc(app.userHandler.UpdateToWorker))
+	mux.Put("/user/:id/city", authMiddleware.ThenFunc(app.userHandler.ChangeCityForUser))
+	mux.Get("/docs/:filename", authMiddleware.ThenFunc(app.userHandler.ServeProofDocument))
+	mux.Post("/user/:id/avatar", authMiddleware.ThenFunc(app.userHandler.UploadAvatar))
+	mux.Get("/images/avatars/:filename", standardMiddleware.ThenFunc(app.userHandler.ServeAvatar))
+	mux.Post("/user/:id/upgrade", authMiddleware.ThenFunc(app.userHandler.UpdateToWorker))
 	mux.Post("/users/check_duplicate", standardMiddleware.ThenFunc(app.userHandler.CheckUserDuplicate))
 	mux.Post("/user/request_reset", authMiddleware.ThenFunc(app.userHandler.RequestPasswordReset))
 	mux.Post("/user/verify_reset_code", authMiddleware.ThenFunc(app.userHandler.VerifyResetCode))

--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -1,17 +1,18 @@
 package handlers
 
 import (
-        "context"
-        "encoding/json"
-        "errors"
-        "fmt"
-        "io"
-        "log"
-        "net/http"
-        "os"
-        "path/filepath"
-        "strconv"
-        "time"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"naimuBack/internal/models"
 	"naimuBack/internal/services"
@@ -62,6 +63,29 @@ func (h *UserHandler) GetUserByID(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(user)
+}
+
+func (h *UserHandler) GetUserByToken(w http.ResponseWriter, r *http.Request) {
+	tokenString := r.Header.Get("Authorization")
+	if tokenString == "" {
+		http.Error(w, "Authorization header missing", http.StatusUnauthorized)
+		return
+	}
+
+	tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+
+	user, err := h.Service.GetUserByToken(r.Context(), tokenString)
+	if err != nil {
+		if errors.Is(err, ErrUserNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
 
@@ -543,85 +567,85 @@ func (h *UserHandler) ServeProofDocument(w http.ResponseWriter, r *http.Request)
 		w.Header().Set("Content-Type", "application/octet-stream")
 	}
 
-        http.ServeFile(w, r, docPath)
+	http.ServeFile(w, r, docPath)
 }
 
 func (h *UserHandler) UploadAvatar(w http.ResponseWriter, r *http.Request) {
-       idStr := r.URL.Query().Get(":id")
-       if idStr == "" {
-               http.Error(w, "Missing user ID", http.StatusBadRequest)
-               return
-       }
-       id, err := strconv.Atoi(idStr)
-       if err != nil {
-               http.Error(w, "Invalid user ID", http.StatusBadRequest)
-               return
-       }
-       if err := r.ParseMultipartForm(10 << 20); err != nil {
-               http.Error(w, "Invalid multipart form", http.StatusBadRequest)
-               return
-       }
-       file, handler, err := r.FormFile("avatar")
-       if err != nil {
-               http.Error(w, "Failed to get avatar file", http.StatusBadRequest)
-               return
-       }
-       defer file.Close()
+	idStr := r.URL.Query().Get(":id")
+	if idStr == "" {
+		http.Error(w, "Missing user ID", http.StatusBadRequest)
+		return
+	}
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "Invalid user ID", http.StatusBadRequest)
+		return
+	}
+	if err := r.ParseMultipartForm(10 << 20); err != nil {
+		http.Error(w, "Invalid multipart form", http.StatusBadRequest)
+		return
+	}
+	file, handler, err := r.FormFile("avatar")
+	if err != nil {
+		http.Error(w, "Failed to get avatar file", http.StatusBadRequest)
+		return
+	}
+	defer file.Close()
 
-       saveDir := "cmd/uploads/avatars"
-       if err := os.MkdirAll(saveDir, 0755); err != nil {
-               http.Error(w, "Failed to create avatar directory", http.StatusInternalServerError)
-               return
-       }
+	saveDir := "cmd/uploads/avatars"
+	if err := os.MkdirAll(saveDir, 0755); err != nil {
+		http.Error(w, "Failed to create avatar directory", http.StatusInternalServerError)
+		return
+	}
 
-       timestamp := time.Now().UnixNano()
-       ext := filepath.Ext(handler.Filename)
-       filename := fmt.Sprintf("avatar_%d%s", timestamp, ext)
-       savePath := filepath.Join(saveDir, filename)
-       publicURL := fmt.Sprintf("/images/avatars/%s", filename)
+	timestamp := time.Now().UnixNano()
+	ext := filepath.Ext(handler.Filename)
+	filename := fmt.Sprintf("avatar_%d%s", timestamp, ext)
+	savePath := filepath.Join(saveDir, filename)
+	publicURL := fmt.Sprintf("/images/avatars/%s", filename)
 
-       dst, err := os.Create(savePath)
-       if err != nil {
-               http.Error(w, "Cannot save avatar", http.StatusInternalServerError)
-               return
-       }
-       defer dst.Close()
+	dst, err := os.Create(savePath)
+	if err != nil {
+		http.Error(w, "Cannot save avatar", http.StatusInternalServerError)
+		return
+	}
+	defer dst.Close()
 
-       if _, err := io.Copy(dst, file); err != nil {
-               http.Error(w, "Failed to write avatar", http.StatusInternalServerError)
-               return
-       }
+	if _, err := io.Copy(dst, file); err != nil {
+		http.Error(w, "Failed to write avatar", http.StatusInternalServerError)
+		return
+	}
 
-       user, err := h.Service.UpdateUserAvatar(r.Context(), id, publicURL)
-       if err != nil {
-               http.Error(w, err.Error(), http.StatusInternalServerError)
-               return
-       }
-       w.Header().Set("Content-Type", "application/json")
-       json.NewEncoder(w).Encode(user)
+	user, err := h.Service.UpdateUserAvatar(r.Context(), id, publicURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(user)
 }
 
 func (h *UserHandler) ServeAvatar(w http.ResponseWriter, r *http.Request) {
-       filename := r.URL.Query().Get(":filename")
-       if filename == "" {
-               http.Error(w, "filename is required", http.StatusBadRequest)
-               return
-       }
-       imagePath := filepath.Join("cmd/uploads/avatars", filename)
-       if _, err := os.Stat(imagePath); os.IsNotExist(err) {
-               http.Error(w, "image not found", http.StatusNotFound)
-               return
-       }
-       ext := filepath.Ext(imagePath)
-       switch ext {
-       case ".jpg", ".jpeg":
-               w.Header().Set("Content-Type", "image/jpeg")
-       case ".png":
-               w.Header().Set("Content-Type", "image/png")
-       case ".gif":
-               w.Header().Set("Content-Type", "image/gif")
-       default:
-               w.Header().Set("Content-Type", "application/octet-stream")
-       }
-       http.ServeFile(w, r, imagePath)
+	filename := r.URL.Query().Get(":filename")
+	if filename == "" {
+		http.Error(w, "filename is required", http.StatusBadRequest)
+		return
+	}
+	imagePath := filepath.Join("cmd/uploads/avatars", filename)
+	if _, err := os.Stat(imagePath); os.IsNotExist(err) {
+		http.Error(w, "image not found", http.StatusNotFound)
+		return
+	}
+	ext := filepath.Ext(imagePath)
+	switch ext {
+	case ".jpg", ".jpeg":
+		w.Header().Set("Content-Type", "image/jpeg")
+	case ".png":
+		w.Header().Set("Content-Type", "image/png")
+	case ".gif":
+		w.Header().Set("Content-Type", "image/gif")
+	default:
+		w.Header().Set("Content-Type", "application/octet-stream")
+	}
+	http.ServeFile(w, r, imagePath)
 }


### PR DESCRIPTION
## Summary
- add handler and service to fetch user data from JWT token
- wire up /user/token route protected by auth middleware

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_689ad3cb57508324889d607565ae0972