### PR TITLE
Add API to retrieve all reviews by user across services

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -51,6 +51,8 @@ type application struct {
 	serviceResponseRepo    *repositories.ServiceResponseRepository
 	userResponsesHandler   *handlers.UserResponsesHandler
 	userResponsesRepo      *repositories.UserResponsesRepository
+	userReviewsHandler     *handlers.UserReviewsHandler
+	userReviewsRepo        *repositories.UserReviewsRepository
 	workHandler            *handlers.WorkHandler
 	workRepo               *repositories.WorkRepository
 	rentHandler            *handlers.RentHandler
@@ -111,6 +113,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	complaintRepo := repositories.ComplaintRepository{DB: db}
 	serviceResponseRepo := repositories.ServiceResponseRepository{DB: db}
 	userResponsesRepo := repositories.UserResponsesRepository{DB: db}
+	userReviewsRepo := repositories.UserReviewsRepository{DB: db}
 	workRepo := repositories.WorkRepository{DB: db}
 	rentRepo := repositories.RentRepository{DB: db}
 	workReviewRepo := repositories.WorkReviewRepository{DB: db}
@@ -146,6 +149,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	complaintService := services.ComplaintService{ComplaintRepo: &complaintRepo}
 	serviceResponseService := &services.ServiceResponseService{ServiceResponseRepo: &serviceResponseRepo}
 	userResponsesService := &services.UserResponsesService{ResponsesRepo: &userResponsesRepo}
+	userReviewsService := &services.UserReviewsService{ReviewsRepo: &userReviewsRepo}
 	workService := &services.WorkService{WorkRepo: &workRepo}
 	rentService := &services.RentService{RentRepo: &rentRepo}
 	workReviewService := &services.WorkReviewService{WorkReviewsRepo: &workReviewRepo}
@@ -183,6 +187,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	complaintHandler := &handlers.ComplaintHandler{Service: &complaintService}
 	serviceResponseHandler := &handlers.ServiceResponseHandler{Service: serviceResponseService}
 	userResponsesHandler := &handlers.UserResponsesHandler{Service: userResponsesService}
+	userReviewsHandler := &handlers.UserReviewsHandler{Service: userReviewsService}
 	workHandler := &handlers.WorkHandler{Service: workService}
 	rentHandler := &handlers.RentHandler{Service: rentService}
 	workReviewHandler := &handlers.WorkReviewHandler{Service: workReviewService}
@@ -237,6 +242,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		complaintHandler:       complaintHandler,
 		serviceResponseHandler: serviceResponseHandler,
 		userResponsesHandler:   userResponsesHandler,
+		userReviewsHandler:     userReviewsHandler,
 		workHandler:            workHandler,
 		rentHandler:            rentHandler,
 		workReviewHandler:      workReviewHandler,

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -90,6 +90,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/review/:service_id", standardMiddleware.ThenFunc(app.reviewsHandler.GetReviewsByServiceID))
 	mux.Put("/review/:id", authMiddleware.ThenFunc(app.reviewsHandler.UpdateReview))
 	mux.Del("/review/:id", authMiddleware.ThenFunc(app.reviewsHandler.DeleteReview))
+	mux.Get("/reviews/:user_id", authMiddleware.ThenFunc(app.userReviewsHandler.GetReviewsByUserID))
 
 	// Service Favorites
 	mux.Post("/favorites", authMiddleware.ThenFunc(app.serviceFavorite.AddToFavorites))

--- a/internal/handlers/user_reviews_handler.go
+++ b/internal/handlers/user_reviews_handler.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/services"
+)
+
+// UserReviewsHandler handles HTTP requests for user reviews.
+type UserReviewsHandler struct {
+	Service *services.UserReviewsService
+}
+
+// GetReviewsByUserID returns all reviews for the specified user.
+func (h *UserReviewsHandler) GetReviewsByUserID(w http.ResponseWriter, r *http.Request) {
+	userIDStr := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	reviews, err := h.Service.GetReviewsByUserID(r.Context(), userID)
+	if err != nil {
+		http.Error(w, "failed to get reviews", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reviews)
+}

--- a/internal/models/user_reviews.go
+++ b/internal/models/user_reviews.go
@@ -1,0 +1,25 @@
+package models
+
+import "time"
+
+// UserReviewItem represents a single review with the associated item details.
+type UserReviewItem struct {
+	ID          int       `json:"id"`
+	Name        string    `json:"name"`
+	Price       float64   `json:"price"`
+	Description string    `json:"description"`
+	Rating      float64   `json:"rating"`
+	Review      string    `json:"review"`
+	ReviewDate  time.Time `json:"review_date"`
+	Type        string    `json:"type"`
+}
+
+// UserReviews aggregates reviews across different entity types.
+type UserReviews struct {
+	Service []UserReviewItem `json:"service"`
+	Ad      []UserReviewItem `json:"ad"`
+	Work    []UserReviewItem `json:"work"`
+	WorkAd  []UserReviewItem `json:"work_ad"`
+	Rent    []UserReviewItem `json:"rent"`
+	RentAd  []UserReviewItem `json:"rent_ad"`
+}

--- a/internal/repositories/user_reviews_repository.go
+++ b/internal/repositories/user_reviews_repository.go
@@ -1,0 +1,92 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+// UserReviewsRepository retrieves user reviews across all entity types.
+type UserReviewsRepository struct {
+	DB *sql.DB
+}
+
+// GetReviewsByUserID returns all reviews for a given user grouped by entity type.
+func (r *UserReviewsRepository) GetReviewsByUserID(ctx context.Context, userID int) (models.UserReviews, error) {
+	var result models.UserReviews
+
+	serviceQuery := `
+        SELECT s.id, s.name, s.price, s.description, rv.rating, rv.review, rv.created_at
+        FROM reviews rv
+        JOIN service s ON s.id = rv.service_id
+        WHERE rv.user_id = ?`
+	if err := r.collect(ctx, &result.Service, serviceQuery, userID, "Service"); err != nil {
+		return result, err
+	}
+
+	adQuery := `
+        SELECT a.id, a.name, a.price, a.description, ar.rating, ar.review, ar.created_at
+        FROM ad_reviews ar
+        JOIN ad a ON a.id = ar.ad_id
+        WHERE ar.user_id = ?`
+	if err := r.collect(ctx, &result.Ad, adQuery, userID, "Ad"); err != nil {
+		return result, err
+	}
+
+	workQuery := `
+        SELECT w.id, w.name, w.price, w.description, wr.rating, wr.review, wr.created_at
+        FROM work_reviews wr
+        JOIN work w ON w.id = wr.work_id
+        WHERE wr.user_id = ?`
+	if err := r.collect(ctx, &result.Work, workQuery, userID, "Work"); err != nil {
+		return result, err
+	}
+
+	workAdQuery := `
+        SELECT wa.id, wa.name, wa.price, wa.description, war.rating, war.review, war.created_at
+        FROM work_ad_reviews war
+        JOIN work_ad wa ON wa.id = war.work_ad_id
+        WHERE war.user_id = ?`
+	if err := r.collect(ctx, &result.WorkAd, workAdQuery, userID, "Work Ad"); err != nil {
+		return result, err
+	}
+
+	rentQuery := `
+        SELECT r.id, r.name, r.price, r.description, rr.rating, rr.review, rr.created_at
+        FROM rent_reviews rr
+        JOIN rent r ON r.id = rr.rent_id
+        WHERE rr.user_id = ?`
+	if err := r.collect(ctx, &result.Rent, rentQuery, userID, "Rent"); err != nil {
+		return result, err
+	}
+
+	rentAdQuery := `
+        SELECT ra.id, ra.name, ra.price, ra.description, rar.rating, rar.review, rar.created_at
+        FROM rent_ad_reviews rar
+        JOIN rent_ad ra ON ra.id = rar.rent_ad_id
+        WHERE rar.user_id = ?`
+	if err := r.collect(ctx, &result.RentAd, rentAdQuery, userID, "Rent Ad"); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (r *UserReviewsRepository) collect(ctx context.Context, dest *[]models.UserReviewItem, query string, userID int, typ string) error {
+	rows, err := r.DB.QueryContext(ctx, query, userID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var item models.UserReviewItem
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.Rating, &item.Review, &item.ReviewDate); err != nil {
+			return err
+		}
+		item.Type = typ
+		*dest = append(*dest, item)
+	}
+	return rows.Err()
+}

--- a/internal/services/user_reviews_service.go
+++ b/internal/services/user_reviews_service.go
@@ -1,0 +1,18 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+// UserReviewsService provides business logic for retrieving user reviews.
+type UserReviewsService struct {
+	ReviewsRepo *repositories.UserReviewsRepository
+}
+
+// GetReviewsByUserID fetches all reviews made by a specific user.
+func (s *UserReviewsService) GetReviewsByUserID(ctx context.Context, userID int) (models.UserReviews, error) {
+	return s.ReviewsRepo.GetReviewsByUserID(ctx, userID)
+}


### PR DESCRIPTION
## Summary
- add models and repository to collect a user's reviews across services, ads, works, work ads, rents and rent ads
- provide service and handler with new GET `/reviews/:user_id` route
- wire new components in application initialization

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689af7c8469083249958b6570566d292