### PR TITLE
Add API to retrieve all reviews by user across services

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -51,6 +51,8 @@ type application struct {
 	serviceResponseRepo    *repositories.ServiceResponseRepository
 	userResponsesHandler   *handlers.UserResponsesHandler
 	userResponsesRepo      *repositories.UserResponsesRepository
+	userReviewsHandler     *handlers.UserReviewsHandler
+	userReviewsRepo        *repositories.UserReviewsRepository
 	workHandler            *handlers.WorkHandler
 	workRepo               *repositories.WorkRepository
 	rentHandler            *handlers.RentHandler
@@ -111,6 +113,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	complaintRepo := repositories.ComplaintRepository{DB: db}
 	serviceResponseRepo := repositories.ServiceResponseRepository{DB: db}
 	userResponsesRepo := repositories.UserResponsesRepository{DB: db}
+	userReviewsRepo := repositories.UserReviewsRepository{DB: db}
 	workRepo := repositories.WorkRepository{DB: db}
 	rentRepo := repositories.RentRepository{DB: db}
 	workReviewRepo := repositories.WorkReviewRepository{DB: db}
@@ -146,6 +149,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	complaintService := services.ComplaintService{ComplaintRepo: &complaintRepo}
 	serviceResponseService := &services.ServiceResponseService{ServiceResponseRepo: &serviceResponseRepo}
 	userResponsesService := &services.UserResponsesService{ResponsesRepo: &userResponsesRepo}
+	userReviewsService := &services.UserReviewsService{ReviewsRepo: &userReviewsRepo}
 	workService := &services.WorkService{WorkRepo: &workRepo}
 	rentService := &services.RentService{RentRepo: &rentRepo}
 	workReviewService := &services.WorkReviewService{WorkReviewsRepo: &workReviewRepo}
@@ -183,6 +187,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	complaintHandler := &handlers.ComplaintHandler{Service: &complaintService}
 	serviceResponseHandler := &handlers.ServiceResponseHandler{Service: serviceResponseService}
 	userResponsesHandler := &handlers.UserResponsesHandler{Service: userResponsesService}
+	userReviewsHandler := &handlers.UserReviewsHandler{Service: userReviewsService}
 	workHandler := &handlers.WorkHandler{Service: workService}
 	rentHandler := &handlers.RentHandler{Service: rentService}
 	workReviewHandler := &handlers.WorkReviewHandler{Service: workReviewService}
@@ -237,6 +242,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		complaintHandler:       complaintHandler,
 		serviceResponseHandler: serviceResponseHandler,
 		userResponsesHandler:   userResponsesHandler,
+		userReviewsHandler:     userReviewsHandler,
 		workHandler:            workHandler,
 		rentHandler:            rentHandler,
 		workReviewHandler:      workReviewHandler,

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -90,6 +90,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/review/:service_id", standardMiddleware.ThenFunc(app.reviewsHandler.GetReviewsByServiceID))
 	mux.Put("/review/:id", authMiddleware.ThenFunc(app.reviewsHandler.UpdateReview))
 	mux.Del("/review/:id", authMiddleware.ThenFunc(app.reviewsHandler.DeleteReview))
+	mux.Get("/reviews/:user_id", authMiddleware.ThenFunc(app.userReviewsHandler.GetReviewsByUserID))
 
 	// Service Favorites
 	mux.Post("/favorites", authMiddleware.ThenFunc(app.serviceFavorite.AddToFavorites))

--- a/internal/handlers/user_reviews_handler.go
+++ b/internal/handlers/user_reviews_handler.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/services"
+)
+
+// UserReviewsHandler handles HTTP requests for user reviews.
+type UserReviewsHandler struct {
+	Service *services.UserReviewsService
+}
+
+// GetReviewsByUserID returns all reviews for the specified user.
+func (h *UserReviewsHandler) GetReviewsByUserID(w http.ResponseWriter, r *http.Request) {
+	userIDStr := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	reviews, err := h.Service.GetReviewsByUserID(r.Context(), userID)
+	if err != nil {
+		http.Error(w, "failed to get reviews", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(reviews)
+}

--- a/internal/models/user_reviews.go
+++ b/internal/models/user_reviews.go
@@ -1,0 +1,25 @@
+package models
+
+import "time"
+
+// UserReviewItem represents a single review with the associated item details.
+type UserReviewItem struct {
+	ID          int       `json:"id"`
+	Name        string    `json:"name"`
+	Price       float64   `json:"price"`
+	Description string    `json:"description"`
+	Rating      float64   `json:"rating"`
+	Review      string    `json:"review"`
+	ReviewDate  time.Time `json:"review_date"`
+	Type        string    `json:"type"`
+}
+
+// UserReviews aggregates reviews across different entity types.
+type UserReviews struct {
+	Service []UserReviewItem `json:"service"`
+	Ad      []UserReviewItem `json:"ad"`
+	Work    []UserReviewItem `json:"work"`
+	WorkAd  []UserReviewItem `json:"work_ad"`
+	Rent    []UserReviewItem `json:"rent"`
+	RentAd  []UserReviewItem `json:"rent_ad"`
+}

--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -93,6 +93,9 @@ func (r *AdRepository) GetAdByID(ctx context.Context, id int) (models.Ad, error)
 			return models.Ad{}, fmt.Errorf("failed to decode images json: %w", err)
 		}
 	}
+
+	s.AvgRating = getAverageRating(ctx, r.DB, "ad_reviews", "ad_id", s.ID)
+
 	count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 	if err == nil {
 		s.User.ReviewsCount = count
@@ -246,6 +249,8 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, categor
 			return nil, 0, 0, fmt.Errorf("json decode error: %w", err)
 		}
 
+		s.AvgRating = getAverageRating(ctx, r.DB, "ad_reviews", "ad_id", s.ID)
+
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.User.ReviewsCount = count
@@ -294,6 +299,8 @@ func (r *AdRepository) GetAdByUserID(ctx context.Context, userID int) ([]models.
 				return nil, fmt.Errorf("json decode error: %w", err)
 			}
 		}
+
+		s.AvgRating = getAverageRating(ctx, r.DB, "ad_reviews", "ad_id", s.ID)
 
 		ads = append(ads, s)
 	}
@@ -415,6 +422,7 @@ func (r *AdRepository) FetchAdByStatusAndUserID(ctx context.Context, userID int,
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, fmt.Errorf("json decode error: %w", err)
 		}
+		s.AvgRating = getAverageRating(ctx, r.DB, "ad_reviews", "ad_id", s.ID)
 		ads = append(ads, s)
 	}
 	return ads, nil
@@ -564,6 +572,8 @@ func (r *AdRepository) GetAdByAdIDAndUserID(ctx context.Context, adID int, userI
 			return models.Ad{}, fmt.Errorf("failed to decode images json: %w", err)
 		}
 	}
+
+	s.AvgRating = getAverageRating(ctx, r.DB, "ad_reviews", "ad_id", s.ID)
 
 	count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 	if err == nil {

--- a/internal/repositories/rating.go
+++ b/internal/repositories/rating.go
@@ -1,0 +1,19 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+func getAverageRating(ctx context.Context, db *sql.DB, table, column string, id int) float64 {
+	query := fmt.Sprintf("SELECT COALESCE(AVG(rating),0) FROM %s WHERE %s = ?", table, column)
+	var avg sql.NullFloat64
+	if err := db.QueryRowContext(ctx, query, id).Scan(&avg); err != nil {
+		return 0
+	}
+	if avg.Valid {
+		return avg.Float64
+	}
+	return 0
+}

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -94,6 +94,9 @@ func (r *RentAdRepository) GetRentAdByID(ctx context.Context, id int) (models.Re
 			return models.RentAd{}, fmt.Errorf("failed to decode images json: %w", err)
 		}
 	}
+
+	s.AvgRating = getAverageRating(ctx, r.DB, "rent_ad_reviews", "rent_ad_id", s.ID)
+
 	count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 	if err == nil {
 		s.User.ReviewsCount = count
@@ -241,6 +244,8 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 			return nil, 0, 0, fmt.Errorf("json decode error: %w", err)
 		}
 
+		s.AvgRating = getAverageRating(ctx, r.DB, "rent_ad_reviews", "rent_ad_id", s.ID)
+
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.User.ReviewsCount = count
@@ -288,6 +293,8 @@ func (r *RentAdRepository) GetRentsAdByUserID(ctx context.Context, userID int) (
 				return nil, fmt.Errorf("json decode error: %w", err)
 			}
 		}
+
+		s.AvgRating = getAverageRating(ctx, r.DB, "rent_ad_reviews", "rent_ad_id", s.ID)
 
 		rents = append(rents, s)
 	}
@@ -409,6 +416,7 @@ func (r *RentAdRepository) FetchByStatusAndUserID(ctx context.Context, userID in
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, fmt.Errorf("json decode error: %w", err)
 		}
+		s.AvgRating = getAverageRating(ctx, r.DB, "rent_ad_reviews", "rent_ad_id", s.ID)
 		rents = append(rents, s)
 	}
 	return rents, nil
@@ -558,6 +566,8 @@ func (r *RentAdRepository) GetRentAdByRentIDAndUserID(ctx context.Context, rentA
 			return models.RentAd{}, fmt.Errorf("failed to decode images json: %w", err)
 		}
 	}
+
+	s.AvgRating = getAverageRating(ctx, r.DB, "rent_ad_reviews", "rent_ad_id", s.ID)
 
 	count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 	if err == nil {

--- a/internal/repositories/user_reviews_repository.go
+++ b/internal/repositories/user_reviews_repository.go
@@ -1,0 +1,92 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+// UserReviewsRepository retrieves user reviews across all entity types.
+type UserReviewsRepository struct {
+	DB *sql.DB
+}
+
+// GetReviewsByUserID returns all reviews for a given user grouped by entity type.
+func (r *UserReviewsRepository) GetReviewsByUserID(ctx context.Context, userID int) (models.UserReviews, error) {
+	var result models.UserReviews
+
+	serviceQuery := `
+        SELECT s.id, s.name, s.price, s.description, rv.rating, rv.review, rv.created_at
+        FROM reviews rv
+        JOIN service s ON s.id = rv.service_id
+        WHERE rv.user_id = ?`
+	if err := r.collect(ctx, &result.Service, serviceQuery, userID, "Service"); err != nil {
+		return result, err
+	}
+
+	adQuery := `
+        SELECT a.id, a.name, a.price, a.description, ar.rating, ar.review, ar.created_at
+        FROM ad_reviews ar
+        JOIN ad a ON a.id = ar.ad_id
+        WHERE ar.user_id = ?`
+	if err := r.collect(ctx, &result.Ad, adQuery, userID, "Ad"); err != nil {
+		return result, err
+	}
+
+	workQuery := `
+        SELECT w.id, w.name, w.price, w.description, wr.rating, wr.review, wr.created_at
+        FROM work_reviews wr
+        JOIN work w ON w.id = wr.work_id
+        WHERE wr.user_id = ?`
+	if err := r.collect(ctx, &result.Work, workQuery, userID, "Work"); err != nil {
+		return result, err
+	}
+
+	workAdQuery := `
+        SELECT wa.id, wa.name, wa.price, wa.description, war.rating, war.review, war.created_at
+        FROM work_ad_reviews war
+        JOIN work_ad wa ON wa.id = war.work_ad_id
+        WHERE war.user_id = ?`
+	if err := r.collect(ctx, &result.WorkAd, workAdQuery, userID, "Work Ad"); err != nil {
+		return result, err
+	}
+
+	rentQuery := `
+        SELECT r.id, r.name, r.price, r.description, rr.rating, rr.review, rr.created_at
+        FROM rent_reviews rr
+        JOIN rent r ON r.id = rr.rent_id
+        WHERE rr.user_id = ?`
+	if err := r.collect(ctx, &result.Rent, rentQuery, userID, "Rent"); err != nil {
+		return result, err
+	}
+
+	rentAdQuery := `
+        SELECT ra.id, ra.name, ra.price, ra.description, rar.rating, rar.review, rar.created_at
+        FROM rent_ad_reviews rar
+        JOIN rent_ad ra ON ra.id = rar.rent_ad_id
+        WHERE rar.user_id = ?`
+	if err := r.collect(ctx, &result.RentAd, rentAdQuery, userID, "Rent Ad"); err != nil {
+		return result, err
+	}
+
+	return result, nil
+}
+
+func (r *UserReviewsRepository) collect(ctx context.Context, dest *[]models.UserReviewItem, query string, userID int, typ string) error {
+	rows, err := r.DB.QueryContext(ctx, query, userID)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var item models.UserReviewItem
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.Rating, &item.Review, &item.ReviewDate); err != nil {
+			return err
+		}
+		item.Type = typ
+		*dest = append(*dest, item)
+	}
+	return rows.Err()
+}

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -98,6 +98,9 @@ func (r *WorkAdRepository) GetWorkAdByID(ctx context.Context, id int) (models.Wo
 			return models.WorkAd{}, fmt.Errorf("failed to decode images json: %w", err)
 		}
 	}
+
+	s.AvgRating = getAverageRating(ctx, r.DB, "work_ad_reviews", "work_ad_id", s.ID)
+
 	count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 	if err == nil {
 		s.User.ReviewsCount = count
@@ -246,6 +249,8 @@ func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int
 			return nil, 0, 0, fmt.Errorf("json decode error: %w", err)
 		}
 
+		s.AvgRating = getAverageRating(ctx, r.DB, "work_ad_reviews", "work_ad_id", s.ID)
+
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.User.ReviewsCount = count
@@ -294,6 +299,8 @@ func (r *WorkAdRepository) GetWorksAdByUserID(ctx context.Context, userID int) (
 				return nil, fmt.Errorf("json decode error: %w", err)
 			}
 		}
+
+		s.AvgRating = getAverageRating(ctx, r.DB, "work_ad_reviews", "work_ad_id", s.ID)
 
 		works_ad = append(works_ad, s)
 	}
@@ -415,6 +422,7 @@ func (r *WorkAdRepository) FetchByStatusAndUserID(ctx context.Context, userID in
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, fmt.Errorf("json decode error: %w", err)
 		}
+		s.AvgRating = getAverageRating(ctx, r.DB, "work_ad_reviews", "work_ad_id", s.ID)
 		works = append(works, s)
 	}
 	return works, nil
@@ -565,6 +573,8 @@ func (r *WorkAdRepository) GetWorkAdByWorkIDAndUserID(ctx context.Context, worka
 			return models.WorkAd{}, fmt.Errorf("failed to decode images json: %w", err)
 		}
 	}
+
+	s.AvgRating = getAverageRating(ctx, r.DB, "work_ad_reviews", "work_ad_id", s.ID)
 
 	count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 	if err == nil {

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -84,7 +84,7 @@ func (r *WorkRepository) GetWorkByID(ctx context.Context, id int) (models.Work, 
 	var imagesJSON []byte
 	err := r.DB.QueryRowContext(ctx, query, id).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-               &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.CityType, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -101,6 +101,9 @@ func (r *WorkRepository) GetWorkByID(ctx context.Context, id int) (models.Work, 
 			return models.Work{}, fmt.Errorf("failed to decode images json: %w", err)
 		}
 	}
+
+	s.AvgRating = getAverageRating(ctx, r.DB, "work_reviews", "work_id", s.ID)
+
 	count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 	if err == nil {
 		s.User.ReviewsCount = count
@@ -240,12 +243,12 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ca
 	for rows.Next() {
 		var s models.Work
 		var imagesJSON []byte
-               err := rows.Scan(
-                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-                        &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
-                        &imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
-                        &s.UpdatedAt,
-                )
+		err := rows.Scan(
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
+			&s.UpdatedAt,
+		)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("scan error: %w", err)
 		}
@@ -253,6 +256,8 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ca
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, 0, 0, fmt.Errorf("json decode error: %w", err)
 		}
+
+		s.AvgRating = getAverageRating(ctx, r.DB, "work_reviews", "work_id", s.ID)
 
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
@@ -273,7 +278,7 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ca
 }
 
 func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]models.Work, error) {
-       query := `
+	query := `
                 SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
                 FROM work s
                 JOIN users u ON s.user_id = u.id
@@ -290,11 +295,11 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 	for rows.Next() {
 		var s models.Work
 		var imagesJSON []byte
-               if err := rows.Scan(
-                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
-                        &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
-                        &s.UpdatedAt,
-                ); err != nil {
+		if err := rows.Scan(
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
+			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
+			&s.UpdatedAt,
+		); err != nil {
 			return nil, err
 		}
 
@@ -303,6 +308,8 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 				return nil, fmt.Errorf("json decode error: %w", err)
 			}
 		}
+
+		s.AvgRating = getAverageRating(ctx, r.DB, "work_reviews", "work_id", s.ID)
 
 		works = append(works, s)
 	}
@@ -373,12 +380,12 @@ func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.Fi
 	var works []models.FilteredWork
 	for rows.Next() {
 		var s models.FilteredWork
-               if err := rows.Scan(
-                        &s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-                        &s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
-                ); err != nil {
-                       return nil, err
-               }
+		if err := rows.Scan(
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
+		); err != nil {
+			return nil, err
+		}
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.UserReviewsCount = count
@@ -390,7 +397,7 @@ func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.Fi
 }
 
 func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int, status string) ([]models.Work, error) {
-       query := `
+	query := `
         SELECT
                 s.id, s.name, s.address, s.price, s.user_id,
                 u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
@@ -411,19 +418,20 @@ func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 	for rows.Next() {
 		var s models.Work
 		var imagesJSON []byte
-               err := rows.Scan(
-                        &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-                        &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
-                        &imagesJSON, &s.CategoryID, &s.SubcategoryID,
-                        &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude,
-                        &s.CreatedAt, &s.UpdatedAt,
-                )
+		err := rows.Scan(
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
+			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude,
+			&s.CreatedAt, &s.UpdatedAt,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("scan error: %w", err)
 		}
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, fmt.Errorf("json decode error: %w", err)
 		}
+		s.AvgRating = getAverageRating(ctx, r.DB, "work_reviews", "work_id", s.ID)
 		works = append(works, s)
 	}
 	return works, nil
@@ -432,7 +440,7 @@ func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req models.FilterWorkRequest, userID int) ([]models.FilteredWork, error) {
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
-       query := `
+	query := `
                SELECT DISTINCT
                        u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
                        s.id, s.name, s.price, s.description,
@@ -508,13 +516,13 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 	var works []models.FilteredWork
 	for rows.Next() {
 		var s models.FilteredWork
-               if err := rows.Scan(
-                        &s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-                        &s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked,
-                ); err != nil {
-                       log.Printf("[ERROR] Failed to scan row: %v", err)
-                       return nil, fmt.Errorf("failed to scan row: %w", err)
-               }
+		if err := rows.Scan(
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked,
+		); err != nil {
+			log.Printf("[ERROR] Failed to scan row: %v", err)
+			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
 			s.UserReviewsCount = count
@@ -553,10 +561,10 @@ func (r *WorkRepository) GetWorkByWorkIDAndUserID(ctx context.Context, workID in
 	var s models.Work
 	var imagesJSON []byte
 
-       err := r.DB.QueryRowContext(ctx, query, userID, workID).Scan(
-               &s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-               &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
-               &imagesJSON, &s.CategoryID, &s.CategoryName,
+	err := r.DB.QueryRowContext(ctx, query, userID, workID).Scan(
+		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,
 		&s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.CityType, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
@@ -574,6 +582,8 @@ func (r *WorkRepository) GetWorkByWorkIDAndUserID(ctx context.Context, workID in
 			return models.Work{}, fmt.Errorf("failed to decode images json: %w", err)
 		}
 	}
+
+	s.AvgRating = getAverageRating(ctx, r.DB, "work_reviews", "work_id", s.ID)
 
 	count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 	if err == nil {

--- a/internal/services/user_reviews_service.go
+++ b/internal/services/user_reviews_service.go
@@ -1,0 +1,18 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+// UserReviewsService provides business logic for retrieving user reviews.
+type UserReviewsService struct {
+	ReviewsRepo *repositories.UserReviewsRepository
+}
+
+// GetReviewsByUserID fetches all reviews made by a specific user.
+func (s *UserReviewsService) GetReviewsByUserID(ctx context.Context, userID int) (models.UserReviews, error) {
+	return s.ReviewsRepo.GetReviewsByUserID(ctx, userID)
+}


### PR DESCRIPTION
## Summary
- add models and repository to collect a user's reviews across services, ads, works, work ads, rents and rent ads
- provide service and handler with new GET `/reviews/:user_id` route
- wire new components in application initialization
- compute average ratings from customer reviews for all service, ad, work, work ad, rent, and rent ad entities

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689af7c8469083249958b6570566d292