### PR TITLE
Ensure avatars return in filtered endpoints

### DIFF
--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -314,13 +314,13 @@ func (r *AdRepository) GetAdByUserID(ctx context.Context, userID int) ([]models.
 
 func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterAdRequest) ([]models.FilteredAd, error) {
 	query := `
-               SELECT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description
-               FROM ad s
-               JOIN users u ON s.user_id = u.id
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description
+       FROM ad s
+       JOIN users u ON s.user_id = u.id
+       WHERE s.price BETWEEN ? AND ?
+`
 	args := []interface{}{req.PriceFrom, req.PriceTo}
 
 	// Category
@@ -432,15 +432,15 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-               SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description,
-                       CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
-               FROM ad s
-               JOIN users u ON s.user_id = u.id
-               LEFT JOIN ad_favorites sf ON sf.ad_id = s.id AND sf.user_id = ?
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT DISTINCT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description,
+               CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
+       FROM ad s
+       JOIN users u ON s.user_id = u.id
+       LEFT JOIN ad_favorites sf ON sf.ad_id = s.id AND sf.user_id = ?
+       WHERE s.price BETWEEN ? AND ?
+`
 
 	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
 

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -308,13 +308,13 @@ func (r *RentAdRepository) GetRentsAdByUserID(ctx context.Context, userID int) (
 
 func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req models.FilterRentAdRequest) ([]models.FilteredRentAd, error) {
 	query := `
-               SELECT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description
-               FROM rent_ad s
-               JOIN users u ON s.user_id = u.id
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description
+       FROM rent_ad s
+       JOIN users u ON s.user_id = u.id
+       WHERE s.price BETWEEN ? AND ?
+`
 	args := []interface{}{req.PriceFrom, req.PriceTo}
 
 	// Category
@@ -426,15 +426,15 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-               SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description,
-                       CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
-               FROM rent_ad s
-               JOIN users u ON s.user_id = u.id
-               LEFT JOIN rent_ad_favorites sf ON sf.rent_ad_id = s.id AND sf.user_id = ?
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT DISTINCT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description,
+               CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
+       FROM rent_ad s
+       JOIN users u ON s.user_id = u.id
+       LEFT JOIN rent_ad_favorites sf ON sf.rent_ad_id = s.id AND sf.user_id = ?
+       WHERE s.price BETWEEN ? AND ?
+`
 
 	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
 

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -308,13 +308,13 @@ func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]mo
 
 func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.FilterRentRequest) ([]models.FilteredRent, error) {
 	query := `
-               SELECT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description
-               FROM rent s
-               JOIN users u ON s.user_id = u.id
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description
+       FROM rent s
+       JOIN users u ON s.user_id = u.id
+       WHERE s.price BETWEEN ? AND ?
+`
 	args := []interface{}{req.PriceFrom, req.PriceTo}
 
 	// Category
@@ -426,15 +426,15 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-               SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description,
-                       CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
-               FROM rent s
-               JOIN users u ON s.user_id = u.id
-               LEFT JOIN rent_favorites sf ON sf.rent_id = s.id AND sf.user_id = ?
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT DISTINCT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description,
+               CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
+       FROM rent s
+       JOIN users u ON s.user_id = u.id
+       LEFT JOIN rent_favorites sf ON sf.rent_id = s.id AND sf.user_id = ?
+       WHERE s.price BETWEEN ? AND ?
+`
 
 	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
 

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -315,13 +315,13 @@ func (r *ServiceRepository) GetServicesByUserID(ctx context.Context, userID int)
 
 func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req models.FilterServicesRequest) ([]models.FilteredService, error) {
 	query := `
-               SELECT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description
-               FROM service s
-               JOIN users u ON s.user_id = u.id
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description
+       FROM service s
+       JOIN users u ON s.user_id = u.id
+       WHERE s.price BETWEEN ? AND ?
+`
 	args := []interface{}{req.PriceFrom, req.PriceTo}
 
 	// Category
@@ -433,15 +433,15 @@ func (r *ServiceRepository) GetFilteredServicesWithLikes(ctx context.Context, re
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-               SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description,
-                       CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
-               FROM service s
-               JOIN users u ON s.user_id = u.id
-               LEFT JOIN service_favorites sf ON sf.service_id = s.id AND sf.user_id = ?
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT DISTINCT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description,
+               CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
+       FROM service s
+       JOIN users u ON s.user_id = u.id
+       LEFT JOIN service_favorites sf ON sf.service_id = s.id AND sf.user_id = ?
+       WHERE s.price BETWEEN ? AND ?
+`
 
 	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
 

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -314,13 +314,13 @@ func (r *WorkAdRepository) GetWorksAdByUserID(ctx context.Context, userID int) (
 
 func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req models.FilterWorkAdRequest) ([]models.FilteredWorkAd, error) {
 	query := `
-               SELECT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description
-               FROM work_ad s
-               JOIN users u ON s.user_id = u.id
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description
+       FROM work_ad s
+       JOIN users u ON s.user_id = u.id
+       WHERE s.price BETWEEN ? AND ?
+`
 	args := []interface{}{req.PriceFrom, req.PriceTo}
 
 	// Category
@@ -432,15 +432,15 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-               SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description,
-                       CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
-               FROM work_ad s
-               JOIN users u ON s.user_id = u.id
-               LEFT JOIN work_ad_favorites sf ON sf.work_ad_id = s.id AND sf.user_id = ?
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT DISTINCT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description,
+               CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
+       FROM work_ad s
+       JOIN users u ON s.user_id = u.id
+       LEFT JOIN work_ad_favorites sf ON sf.work_ad_id = s.id AND sf.user_id = ?
+       WHERE s.price BETWEEN ? AND ?
+`
 
 	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
 

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -323,13 +323,13 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 
 func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.FilterWorkRequest) ([]models.FilteredWork, error) {
 	query := `
-               SELECT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description
-               FROM work s
-               JOIN users u ON s.user_id = u.id
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description
+       FROM work s
+       JOIN users u ON s.user_id = u.id
+       WHERE s.price BETWEEN ? AND ?
+`
 	args := []interface{}{req.PriceFrom, req.PriceTo}
 
 	// Category
@@ -441,15 +441,15 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-               SELECT DISTINCT
-                       u.id, u.name, u.surname, u.phone, u.avatar_path, u.review_rating,
-                       s.id, s.name, s.price, s.description,
-                       CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
-               FROM work s
-               JOIN users u ON s.user_id = u.id
-               LEFT JOIN work_favorites sf ON sf.work_id = s.id AND sf.user_id = ?
-               WHERE s.price BETWEEN ? AND ?
-       `
+       SELECT DISTINCT
+               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+               s.id, s.name, s.price, s.description,
+               CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked
+       FROM work s
+       JOIN users u ON s.user_id = u.id
+       LEFT JOIN work_favorites sf ON sf.work_id = s.id AND sf.user_id = ?
+       WHERE s.price BETWEEN ? AND ?
+`
 
 	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
 


### PR DESCRIPTION
## Summary
- Always include user avatar path in filtered service, work, rent, and ad queries
- Use `COALESCE` to provide empty string when avatar is missing

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_689b24eb99308324aaff5a4f54281e03