### PR TITLE
Add service response confirmation and chat creation

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -17,82 +17,84 @@ import (
 )
 
 type application struct {
-	errorLog               *log.Logger
-	infoLog                *log.Logger
-	userHandler            *handlers.UserHandler
-	userRepo               *repositories.UserRepository
-	serviceHandler         *handlers.ServiceHandler
-	serviceRepo            *repositories.ServiceRepository
-	categoryHandler        *handlers.CategoryHandler
-	categoryRepo           *repositories.CategoryRepository
-	rentCategoryHandler    *handlers.RentCategoryHandler
-	rentCategoryRepo       *repositories.RentCategoryRepository
-	workCategoryHandler    *handlers.WorkCategoryHandler
-	workCategoryRepo       *repositories.WorkCategoryRepository
-	reviewsHandler         *handlers.ReviewHandler
-	reviewsRepo            *repositories.ReviewRepository
-	serviceFavorite        *handlers.ServiceFavoriteHandler
-	serviceFavoriteRepo    *repositories.ServiceFavoriteRepository
-	subcategoryHandler     handlers.SubcategoryHandler
-	subcategoryRepo        repositories.SubcategoryRepository
-	rentSubcategoryHandler handlers.RentSubcategoryHandler
-	rentSubcategoryRepo    repositories.RentSubcategoryRepository
-	workSubcategoryHandler handlers.WorkSubcategoryHandler
-	workSubcategoryRepo    repositories.WorkSubcategoryRepository
-	cityHandler            handlers.CityHandler
-	cityRepo               repositories.CityRepository
-	wsManager              *WebSocketManager
-	chatHandler            *handlers.ChatHandler
-	messageHandler         *handlers.MessageHandler
-	db                     *sql.DB
-	complaintHandler       *handlers.ComplaintHandler
-	complaintRepo          *repositories.ComplaintRepository
-	serviceResponseHandler *handlers.ServiceResponseHandler
-	serviceResponseRepo    *repositories.ServiceResponseRepository
-	userResponsesHandler   *handlers.UserResponsesHandler
-	userResponsesRepo      *repositories.UserResponsesRepository
-	userReviewsHandler     *handlers.UserReviewsHandler
-	userReviewsRepo        *repositories.UserReviewsRepository
-	workHandler            *handlers.WorkHandler
-	workRepo               *repositories.WorkRepository
-	rentHandler            *handlers.RentHandler
-	rentRepo               *repositories.RentRepository
-	workReviewHandler      *handlers.WorkReviewHandler
-	workReviewRepo         *repositories.WorkReviewRepository
-	workResponseHandler    *handlers.WorkResponseHandler
-	workResponseRepo       *repositories.WorkResponseRepository
-	workFavoriteHandler    *handlers.WorkFavoriteHandler
-	workFavoriteRepo       *repositories.WorkFavoriteRepository
-	rentReviewHandler      *handlers.RentReviewHandler
-	rentReviewRepo         *repositories.RentReviewRepository
-	rentResponseHandler    *handlers.RentResponseHandler
-	rentResponseRepo       *repositories.RentResponseRepository
-	rentFavoriteHandler    *handlers.RentFavoriteHandler
-	rentFavoriteRepo       *repositories.RentFavoriteRepository
-	adHandler              *handlers.AdHandler
-	adRepo                 *repositories.AdRepository
-	adReviewHandler        *handlers.AdReviewHandler
-	adReviewRepo           *repositories.AdReviewRepository
-	adResponseHandler      *handlers.AdResponseHandler
-	adResponseRepo         *repositories.AdResponseRepository
-	adFavoriteHandler      *handlers.AdFavoriteHandler
-	adFavoriteRepo         *repositories.AdFavoriteRepository
-	workAdHandler          *handlers.WorkAdHandler
-	workAdRepo             *repositories.WorkAdRepository
-	workAdReviewHandler    *handlers.WorkAdReviewHandler
-	workAdReviewRepo       *repositories.WorkAdReviewRepository
-	workAdResponseHandler  *handlers.WorkAdResponseHandler
-	workAdResponseRepo     *repositories.WorkAdResponseRepository
-	workAdFavoriteHandler  *handlers.WorkAdFavoriteHandler
-	workAdFavoriteRepo     *repositories.WorkAdFavoriteRepository
-	rentAdHandler          *handlers.RentAdHandler
-	rentAdRepo             *repositories.AdRepository
-	rentAdReviewHandler    *handlers.RentAdReviewHandler
-	rentAdReviewRepo       *repositories.AdReviewRepository
-	rentAdResponseHandler  *handlers.RentAdResponseHandler
-	rentAdResponseRepo     *repositories.AdResponseRepository
-	rentAdFavoriteHandler  *handlers.RentAdFavoriteHandler
-	rentAdFavoriteRepo     *repositories.AdFavoriteRepository
+	errorLog                   *log.Logger
+	infoLog                    *log.Logger
+	userHandler                *handlers.UserHandler
+	userRepo                   *repositories.UserRepository
+	serviceHandler             *handlers.ServiceHandler
+	serviceRepo                *repositories.ServiceRepository
+	categoryHandler            *handlers.CategoryHandler
+	categoryRepo               *repositories.CategoryRepository
+	rentCategoryHandler        *handlers.RentCategoryHandler
+	rentCategoryRepo           *repositories.RentCategoryRepository
+	workCategoryHandler        *handlers.WorkCategoryHandler
+	workCategoryRepo           *repositories.WorkCategoryRepository
+	reviewsHandler             *handlers.ReviewHandler
+	reviewsRepo                *repositories.ReviewRepository
+	serviceFavorite            *handlers.ServiceFavoriteHandler
+	serviceFavoriteRepo        *repositories.ServiceFavoriteRepository
+	subcategoryHandler         handlers.SubcategoryHandler
+	subcategoryRepo            repositories.SubcategoryRepository
+	rentSubcategoryHandler     handlers.RentSubcategoryHandler
+	rentSubcategoryRepo        repositories.RentSubcategoryRepository
+	workSubcategoryHandler     handlers.WorkSubcategoryHandler
+	workSubcategoryRepo        repositories.WorkSubcategoryRepository
+	cityHandler                handlers.CityHandler
+	cityRepo                   repositories.CityRepository
+	wsManager                  *WebSocketManager
+	chatHandler                *handlers.ChatHandler
+	messageHandler             *handlers.MessageHandler
+	db                         *sql.DB
+	complaintHandler           *handlers.ComplaintHandler
+	complaintRepo              *repositories.ComplaintRepository
+	serviceResponseHandler     *handlers.ServiceResponseHandler
+	serviceResponseRepo        *repositories.ServiceResponseRepository
+	serviceConfirmationHandler *handlers.ServiceConfirmationHandler
+	serviceConfirmationRepo    *repositories.ServiceConfirmationRepository
+	userResponsesHandler       *handlers.UserResponsesHandler
+	userResponsesRepo          *repositories.UserResponsesRepository
+	userReviewsHandler         *handlers.UserReviewsHandler
+	userReviewsRepo            *repositories.UserReviewsRepository
+	workHandler                *handlers.WorkHandler
+	workRepo                   *repositories.WorkRepository
+	rentHandler                *handlers.RentHandler
+	rentRepo                   *repositories.RentRepository
+	workReviewHandler          *handlers.WorkReviewHandler
+	workReviewRepo             *repositories.WorkReviewRepository
+	workResponseHandler        *handlers.WorkResponseHandler
+	workResponseRepo           *repositories.WorkResponseRepository
+	workFavoriteHandler        *handlers.WorkFavoriteHandler
+	workFavoriteRepo           *repositories.WorkFavoriteRepository
+	rentReviewHandler          *handlers.RentReviewHandler
+	rentReviewRepo             *repositories.RentReviewRepository
+	rentResponseHandler        *handlers.RentResponseHandler
+	rentResponseRepo           *repositories.RentResponseRepository
+	rentFavoriteHandler        *handlers.RentFavoriteHandler
+	rentFavoriteRepo           *repositories.RentFavoriteRepository
+	adHandler                  *handlers.AdHandler
+	adRepo                     *repositories.AdRepository
+	adReviewHandler            *handlers.AdReviewHandler
+	adReviewRepo               *repositories.AdReviewRepository
+	adResponseHandler          *handlers.AdResponseHandler
+	adResponseRepo             *repositories.AdResponseRepository
+	adFavoriteHandler          *handlers.AdFavoriteHandler
+	adFavoriteRepo             *repositories.AdFavoriteRepository
+	workAdHandler              *handlers.WorkAdHandler
+	workAdRepo                 *repositories.WorkAdRepository
+	workAdReviewHandler        *handlers.WorkAdReviewHandler
+	workAdReviewRepo           *repositories.WorkAdReviewRepository
+	workAdResponseHandler      *handlers.WorkAdResponseHandler
+	workAdResponseRepo         *repositories.WorkAdResponseRepository
+	workAdFavoriteHandler      *handlers.WorkAdFavoriteHandler
+	workAdFavoriteRepo         *repositories.WorkAdFavoriteRepository
+	rentAdHandler              *handlers.RentAdHandler
+	rentAdRepo                 *repositories.AdRepository
+	rentAdReviewHandler        *handlers.RentAdReviewHandler
+	rentAdReviewRepo           *repositories.AdReviewRepository
+	rentAdResponseHandler      *handlers.RentAdResponseHandler
+	rentAdResponseRepo         *repositories.AdResponseRepository
+	rentAdFavoriteHandler      *handlers.RentAdFavoriteHandler
+	rentAdFavoriteRepo         *repositories.AdFavoriteRepository
 
 	// authService *services/*/.AuthService
 }
@@ -111,7 +113,9 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	workSubcategoryRepo := repositories.WorkSubcategoryRepository{DB: db}
 	cityRepo := repositories.CityRepository{DB: db}
 	complaintRepo := repositories.ComplaintRepository{DB: db}
+	chatRepo := repositories.ChatRepository{Db: db}
 	serviceResponseRepo := repositories.ServiceResponseRepository{DB: db}
+	serviceConfirmationRepo := repositories.ServiceConfirmationRepository{DB: db}
 	userResponsesRepo := repositories.UserResponsesRepository{DB: db}
 	userReviewsRepo := repositories.UserReviewsRepository{DB: db}
 	workRepo := repositories.WorkRepository{DB: db}
@@ -147,7 +151,8 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	workSubcategoryService := services.WorkSubcategoryService{SubcategoryRepo: &workSubcategoryRepo}
 	cityService := services.CityService{CityRepo: &cityRepo}
 	complaintService := services.ComplaintService{ComplaintRepo: &complaintRepo}
-	serviceResponseService := &services.ServiceResponseService{ServiceResponseRepo: &serviceResponseRepo}
+	serviceResponseService := &services.ServiceResponseService{ServiceResponseRepo: &serviceResponseRepo, ServiceRepo: &serviceRepo, ChatRepo: &chatRepo, ConfirmationRepo: &serviceConfirmationRepo}
+	serviceConfirmationService := &services.ServiceConfirmationService{ConfirmationRepo: &serviceConfirmationRepo}
 	userResponsesService := &services.UserResponsesService{ResponsesRepo: &userResponsesRepo}
 	userReviewsService := &services.UserReviewsService{ReviewsRepo: &userReviewsRepo}
 	workService := &services.WorkService{WorkRepo: &workRepo}
@@ -186,6 +191,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	cityHandler := handlers.CityHandler{Service: &cityService}
 	complaintHandler := &handlers.ComplaintHandler{Service: &complaintService}
 	serviceResponseHandler := &handlers.ServiceResponseHandler{Service: serviceResponseService}
+	serviceConfirmationHandler := &handlers.ServiceConfirmationHandler{Service: serviceConfirmationService}
 	userResponsesHandler := &handlers.UserResponsesHandler{Service: userResponsesService}
 	userReviewsHandler := &handlers.UserReviewsHandler{Service: userReviewsService}
 	workHandler := &handlers.WorkHandler{Service: workService}
@@ -211,9 +217,8 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 
 	// Chat
 	wsManager := NewWebSocketManager()
-	// Создание репозитория, сервиса и обработчика для чатов
-	chatRepo := &repositories.ChatRepository{Db: db}
-	chatService := &services.ChatService{ChatRepo: chatRepo}
+	// Создание сервиса и обработчика для чатов
+	chatService := &services.ChatService{ChatRepo: &chatRepo}
 	chatHandler := &handlers.ChatHandler{ChatService: chatService}
 
 	// Создание репозитория, сервиса и обработчика для сообщений
@@ -222,47 +227,48 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	messageHandler := &handlers.MessageHandler{MessageService: messageService}
 
 	return &application{
-		errorLog:               errorLog,
-		infoLog:                infoLog,
-		userHandler:            userHandler,
-		serviceHandler:         serviceHandler,
-		categoryHandler:        categoryHandler,
-		rentCategoryHandler:    rentCategoryHandler,
-		workCategoryHandler:    workCategoryHandler,
-		reviewsHandler:         reviewHandler,
-		serviceFavorite:        serviceFavoriteHandler,
-		subcategoryHandler:     subcategoryHandler,
-		rentSubcategoryHandler: rentSubcategoryHandler,
-		workSubcategoryHandler: workSubcategoryHandler,
-		cityHandler:            cityHandler,
-		chatHandler:            chatHandler,
-		messageHandler:         messageHandler,
-		wsManager:              wsManager,
-		db:                     db,
-		complaintHandler:       complaintHandler,
-		serviceResponseHandler: serviceResponseHandler,
-		userResponsesHandler:   userResponsesHandler,
-		userReviewsHandler:     userReviewsHandler,
-		workHandler:            workHandler,
-		rentHandler:            rentHandler,
-		workReviewHandler:      workReviewHandler,
-		workResponseHandler:    workResponseHandler,
-		workFavoriteHandler:    workFavoriteHandler,
-		rentReviewHandler:      rentReviewHandler,
-		rentResponseHandler:    rentResponseHandler,
-		rentFavoriteHandler:    rentFavoriteHandler,
-		adHandler:              adHandler,
-		adReviewHandler:        adReviewHandler,
-		adResponseHandler:      adResponseHandler,
-		adFavoriteHandler:      adFavoriteHandler,
-		workAdHandler:          workAdHandler,
-		workAdReviewHandler:    workAdReviewHandler,
-		workAdResponseHandler:  workAdResponseHandler,
-		workAdFavoriteHandler:  workAdFavoriteHandler,
-		rentAdHandler:          rentAdHandler,
-		rentAdReviewHandler:    rentADReviewHandler,
-		rentAdResponseHandler:  rentAdResponseHandler,
-		rentAdFavoriteHandler:  rentAdFavoriteHandler,
+		errorLog:                   errorLog,
+		infoLog:                    infoLog,
+		userHandler:                userHandler,
+		serviceHandler:             serviceHandler,
+		categoryHandler:            categoryHandler,
+		rentCategoryHandler:        rentCategoryHandler,
+		workCategoryHandler:        workCategoryHandler,
+		reviewsHandler:             reviewHandler,
+		serviceFavorite:            serviceFavoriteHandler,
+		subcategoryHandler:         subcategoryHandler,
+		rentSubcategoryHandler:     rentSubcategoryHandler,
+		workSubcategoryHandler:     workSubcategoryHandler,
+		cityHandler:                cityHandler,
+		chatHandler:                chatHandler,
+		messageHandler:             messageHandler,
+		wsManager:                  wsManager,
+		db:                         db,
+		complaintHandler:           complaintHandler,
+		serviceResponseHandler:     serviceResponseHandler,
+		serviceConfirmationHandler: serviceConfirmationHandler,
+		userResponsesHandler:       userResponsesHandler,
+		userReviewsHandler:         userReviewsHandler,
+		workHandler:                workHandler,
+		rentHandler:                rentHandler,
+		workReviewHandler:          workReviewHandler,
+		workResponseHandler:        workResponseHandler,
+		workFavoriteHandler:        workFavoriteHandler,
+		rentReviewHandler:          rentReviewHandler,
+		rentResponseHandler:        rentResponseHandler,
+		rentFavoriteHandler:        rentFavoriteHandler,
+		adHandler:                  adHandler,
+		adReviewHandler:            adReviewHandler,
+		adResponseHandler:          adResponseHandler,
+		adFavoriteHandler:          adFavoriteHandler,
+		workAdHandler:              workAdHandler,
+		workAdReviewHandler:        workAdReviewHandler,
+		workAdResponseHandler:      workAdResponseHandler,
+		workAdFavoriteHandler:      workAdFavoriteHandler,
+		rentAdHandler:              rentAdHandler,
+		rentAdReviewHandler:        rentADReviewHandler,
+		rentAdResponseHandler:      rentAdResponseHandler,
+		rentAdFavoriteHandler:      rentAdFavoriteHandler,
 		//authService:    authService,
 	}
 }

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -54,6 +54,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/service/user/:user_id", standardMiddleware.ThenFunc(app.serviceHandler.GetServiceByUserID))           //РАБОТАЕТ
 	mux.Post("/service/filtered", standardMiddleware.ThenFunc(app.serviceHandler.GetFilteredServicesPost))          //РАБОТАЕТ
 	mux.Post("/service/status", authMiddleware.ThenFunc(app.serviceHandler.GetServicesByStatusAndUserID))
+	mux.Post("/service/confirm", authMiddleware.ThenFunc(app.serviceConfirmationHandler.ConfirmService))
 	mux.Get("/images/services/:filename", http.HandlerFunc(app.serviceHandler.ServeServiceImage))
 	mux.Post("/service/filtered/:user_id", authMiddleware.ThenFunc(app.serviceHandler.GetFilteredServicesWithLikes))
 	mux.Get("/service/service_id/:service_id/user/:user_id", standardMiddleware.ThenFunc(app.serviceHandler.GetServiceByServiceIDAndUserID))

--- a/db/migrations/000046_service_confirmations.down.sql
+++ b/db/migrations/000046_service_confirmations.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS service_confirmations;
+
+use naimudb;

--- a/db/migrations/000046_service_confirmations.up.sql
+++ b/db/migrations/000046_service_confirmations.up.sql
@@ -1,0 +1,16 @@
+CREATE TABLE service_confirmations (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    service_id INT NOT NULL,
+    chat_id INT NOT NULL,
+    client_id INT NOT NULL,
+    performer_id INT NOT NULL,
+    confirmed BOOLEAN DEFAULT FALSE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (service_id) REFERENCES service(id) ON DELETE CASCADE,
+    FOREIGN KEY (chat_id) REFERENCES chats(id) ON DELETE CASCADE,
+    FOREIGN KEY (client_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (performer_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+use naimudb;

--- a/internal/handlers/service_confirmation_handler.go
+++ b/internal/handlers/service_confirmation_handler.go
@@ -1,0 +1,28 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"naimuBack/internal/services"
+)
+
+type ServiceConfirmationHandler struct {
+	Service *services.ServiceConfirmationService
+}
+
+func (h *ServiceConfirmationHandler) ConfirmService(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ServiceID   int `json:"service_id"`
+		PerformerID int `json:"performer_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.ConfirmService(r.Context(), req.ServiceID, req.PerformerID); err != nil {
+		http.Error(w, "Could not confirm service", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/models/service_confirmation.go
+++ b/internal/models/service_confirmation.go
@@ -1,0 +1,14 @@
+package models
+
+import "time"
+
+type ServiceConfirmation struct {
+	ID          int        `json:"id"`
+	ServiceID   int        `json:"service_id"`
+	ChatID      int        `json:"chat_id"`
+	ClientID    int        `json:"client_id"`
+	PerformerID int        `json:"performer_id"`
+	Confirmed   bool       `json:"confirmed"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   *time.Time `json:"updated_at,omitempty"`
+}

--- a/internal/models/service_response.go
+++ b/internal/models/service_response.go
@@ -8,6 +8,7 @@ type ServiceResponses struct {
 	ID          int        `json:"id"`
 	UserID      int        `json:"user_id,omitempty"`
 	ServiceID   int        `json:"service_id,omitempty"`
+	ChatID      int        `json:"chat_id,omitempty"`
 	Price       float64    `json:"price"`
 	Description string     `json:"description"`
 	CreatedAt   time.Time  `json:"created_at"`

--- a/internal/repositories/service_confirmation_repository.go
+++ b/internal/repositories/service_confirmation_repository.go
@@ -1,0 +1,51 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"naimuBack/internal/models"
+	"time"
+)
+
+type ServiceConfirmationRepository struct {
+	DB *sql.DB
+}
+
+func (r *ServiceConfirmationRepository) Create(ctx context.Context, sc models.ServiceConfirmation) (models.ServiceConfirmation, error) {
+	query := `INSERT INTO service_confirmations (service_id, chat_id, client_id, performer_id, confirmed, created_at) VALUES (?, ?, ?, ?, false, ?)`
+	now := time.Now()
+	res, err := r.DB.ExecContext(ctx, query, sc.ServiceID, sc.ChatID, sc.ClientID, sc.PerformerID, now)
+	if err != nil {
+		return models.ServiceConfirmation{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return models.ServiceConfirmation{}, err
+	}
+	sc.ID = int(id)
+	sc.CreatedAt = now
+	return sc, nil
+}
+
+func (r *ServiceConfirmationRepository) Confirm(ctx context.Context, serviceID, performerID int) error {
+	tx, err := r.DB.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	now := time.Now()
+	_, err = tx.ExecContext(ctx, `UPDATE service_confirmations SET confirmed = true, updated_at = ? WHERE service_id = ? AND performer_id = ?`, now, serviceID, performerID)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `DELETE FROM service_responses WHERE service_id = ? AND user_id <> ?`, serviceID, performerID)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `UPDATE service SET status = 'in progress' WHERE id = ?`, serviceID)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}

--- a/internal/services/service_confirmation_service.go
+++ b/internal/services/service_confirmation_service.go
@@ -1,0 +1,14 @@
+package services
+
+import (
+	"context"
+	"naimuBack/internal/repositories"
+)
+
+type ServiceConfirmationService struct {
+	ConfirmationRepo *repositories.ServiceConfirmationRepository
+}
+
+func (s *ServiceConfirmationService) ConfirmService(ctx context.Context, serviceID, performerID int) error {
+	return s.ConfirmationRepo.Confirm(ctx, serviceID, performerID)
+}

--- a/internal/services/service_response_service.go
+++ b/internal/services/service_response_service.go
@@ -8,8 +8,33 @@ import (
 
 type ServiceResponseService struct {
 	ServiceResponseRepo *repositories.ServiceResponseRepository
+	ServiceRepo         *repositories.ServiceRepository
+	ChatRepo            *repositories.ChatRepository
+	ConfirmationRepo    *repositories.ServiceConfirmationRepository
 }
 
 func (s *ServiceResponseService) CreateServiceResponse(ctx context.Context, resp models.ServiceResponses) (models.ServiceResponses, error) {
-	return s.ServiceResponseRepo.CreateResponse(ctx, resp)
+	resp, err := s.ServiceResponseRepo.CreateResponse(ctx, resp)
+	if err != nil {
+		return resp, err
+	}
+	service, err := s.ServiceRepo.GetServiceByID(ctx, resp.ServiceID)
+	if err != nil {
+		return resp, err
+	}
+	chatID, err := s.ChatRepo.CreateChat(ctx, models.Chat{User1ID: service.UserID, User2ID: resp.UserID})
+	if err != nil {
+		return resp, err
+	}
+	resp.ChatID = chatID
+	_, err = s.ConfirmationRepo.Create(ctx, models.ServiceConfirmation{
+		ServiceID:   resp.ServiceID,
+		ChatID:      chatID,
+		ClientID:    service.UserID,
+		PerformerID: resp.UserID,
+	})
+	if err != nil {
+		return resp, err
+	}
+	return resp, nil
 }


### PR DESCRIPTION
## Summary
- create service_confirmations table for tracking performer approval
- generate chat and confirmation record when responding to a service
- allow service author to confirm performer, dropping other responses and setting status to in progress

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c188be6fc83249a10b783ebdebdb4