### PR TITLE
Add API to list chats for ad owners

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -136,6 +136,7 @@ func (app *application) routes() http.Handler {
 	mux.Post("/api/chats", authMiddleware.ThenFunc(app.chatHandler.CreateChat))
 	mux.Get("/api/chats/:id", authMiddleware.ThenFunc(app.chatHandler.GetChatByID))
 	mux.Get("/api/chats", authMiddleware.ThenFunc(app.chatHandler.GetAllChats))
+	mux.Get("/api/chats/user/:user_id", authMiddleware.ThenFunc(app.chatHandler.GetChatsByUserID))
 	mux.Del("/api/chats/:id", authMiddleware.ThenFunc(app.chatHandler.DeleteChat))
 
 	mux.Post("/api/messages", authMiddleware.ThenFunc(app.messageHandler.CreateMessage))

--- a/internal/handlers/chat_handler.go
+++ b/internal/handlers/chat_handler.go
@@ -65,6 +65,24 @@ func (h *ChatHandler) GetAllChats(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(chats)
 }
 
+func (h *ChatHandler) GetChatsByUserID(w http.ResponseWriter, r *http.Request) {
+	idParam := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(idParam)
+	if err != nil || userID <= 0 {
+		http.Error(w, "Invalid user ID", http.StatusBadRequest)
+		return
+	}
+
+	chats, err := h.ChatService.GetChatsByUserID(r.Context(), userID)
+	if err != nil {
+		http.Error(w, "Failed to retrieve chats", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(chats)
+}
+
 func (h *ChatHandler) DeleteChat(w http.ResponseWriter, r *http.Request) {
 	idParam := r.URL.Query().Get(":id")
 	id, err := strconv.Atoi(idParam)

--- a/internal/models/chats_by_user.go
+++ b/internal/models/chats_by_user.go
@@ -1,0 +1,17 @@
+package models
+
+// ChatUser contains information about a user participating in a chat and the price they offered.
+type ChatUser struct {
+	ID      int     `json:"id"`
+	Name    string  `json:"name"`
+	Surname string  `json:"surname"`
+	Price   float64 `json:"price"`
+	ChatID  int     `json:"chat_id"`
+}
+
+// AdChats groups chat users by advertisement.
+type AdChats struct {
+	AdID   int        `json:"ad_id"`
+	AdName string     `json:"ad_name"`
+	Users  []ChatUser `json:"users"`
+}

--- a/internal/services/chat_service.go
+++ b/internal/services/chat_service.go
@@ -35,6 +35,10 @@ func (s *ChatService) GetAllChats(ctx context.Context) ([]models.Chat, error) {
 	return s.ChatRepo.GetAllChats(ctx)
 }
 
+func (s *ChatService) GetChatsByUserID(ctx context.Context, userID int) ([]models.AdChats, error) {
+	return s.ChatRepo.GetChatsByUserID(ctx, userID)
+}
+
 func (s *ChatService) DeleteChat(ctx context.Context, id int) error {
 	return s.ChatRepo.DeleteChat(ctx, id)
 }


### PR DESCRIPTION
## Summary
- add models to represent chats grouped by advertisement
- implement repository, service and handler logic to fetch chats by user
- expose `/api/chats/user/:user_id` route for authors to view chats per ad

## Testing
- `go test ./...`
- `go vet ./...` *(struct tag warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689c807d6790832494d5b7df3ce58367