### PR TITLE
Expose rating and review stats for chat users

### DIFF
--- a/internal/models/chats_by_user.go
+++ b/internal/models/chats_by_user.go
@@ -2,11 +2,13 @@ package models
 
 // ChatUser contains information about a user participating in a chat and the price they offered.
 type ChatUser struct {
-	ID      int     `json:"id"`
-	Name    string  `json:"name"`
-	Surname string  `json:"surname"`
-	Price   float64 `json:"price"`
-	ChatID  int     `json:"chat_id"`
+	ID           int     `json:"id"`
+	Name         string  `json:"name"`
+	Surname      string  `json:"surname"`
+	Price        float64 `json:"price"`
+	ChatID       int     `json:"chat_id"`
+	ReviewRating float64 `json:"review_rating"`
+	ReviewsCount int     `json:"reviews_count"`
 }
 
 // AdChats groups chat users by advertisement.

--- a/internal/repositories/chat_repository.go
+++ b/internal/repositories/chat_repository.go
@@ -146,6 +146,16 @@ func (r *ChatRepository) GetChatsByUserID(ctx context.Context, userID int) ([]mo
 			return nil, err
 		}
 
+		rating, err := getUserAverageRating(ctx, r.Db, user.ID)
+		if err == nil {
+			user.ReviewRating = rating
+		}
+
+		count, err := getUserTotalReviews(ctx, r.Db, user.ID)
+		if err == nil {
+			user.ReviewsCount = count
+		}
+
 		if idx, ok := adIndex[adID]; ok {
 			result[idx].Users = append(result[idx].Users, user)
 		} else {


### PR DESCRIPTION
## Summary
- compute each chat participant's average rating across all their services
- include user rating and total review count in chat responses

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689d8b711fe083249918d6374c838055