### PR TITLE
feat: add basic subscription support

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -107,6 +107,8 @@ type application struct {
 	workConfirmationRepo      *repositories.WorkConfirmationRepository
 	rentConfirmationHandler   *handlers.RentConfirmationHandler
 	rentConfirmationRepo      *repositories.RentConfirmationRepository
+	subscriptionHandler       *handlers.SubscriptionHandler
+	subscriptionRepo          *repositories.SubscriptionRepository
 
 	// authService *services/*/.AuthService
 }
@@ -156,6 +158,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	workAdConfirmationRepo := repositories.WorkAdConfirmationRepository{DB: db}
 	rentConfirmationRepo := repositories.RentConfirmationRepository{DB: db}
 	rentAdConfirmationRepo := repositories.RentAdConfirmationRepository{DB: db}
+	subscriptionRepo := repositories.SubscriptionRepository{DB: db}
 	// Services
 	userService := &services.UserService{UserRepo: &userRepo}
 	serviceService := &services.ServiceService{ServiceRepo: &serviceRepo}
@@ -185,6 +188,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	adReviewService := &services.AdReviewService{AdReviewsRepo: &adReviewRepo}
 	adResponseService := &services.AdResponseService{AdResponseRepo: &adResponseRepo, AdRepo: &adRepo, ChatRepo: &chatRepo, ConfirmationRepo: &adConfirmationRepo, MessageRepo: &messageRepo}
 	adFavoriteService := &services.AdFavoriteService{AdFavoriteRepo: &adFavoriteRepo}
+	subscriptionService := &services.SubscriptionService{Repo: &subscriptionRepo}
 	workAdService := &services.WorkAdService{WorkAdRepo: &workAdRepo}
 	workAdReviewService := &services.WorkAdReviewService{WorkAdReviewsRepo: &workAdReviewRepo}
 	workAdResponseService := &services.WorkAdResponseService{WorkAdResponseRepo: &workAdResponseRepo, WorkAdRepo: &workAdRepo, ChatRepo: &chatRepo, ConfirmationRepo: &workAdConfirmationRepo, MessageRepo: &messageRepo}
@@ -229,6 +233,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	adReviewHandler := &handlers.AdReviewHandler{Service: adReviewService}
 	adResponseHandler := &handlers.AdResponseHandler{Service: adResponseService}
 	adFavoriteHandler := &handlers.AdFavoriteHandler{Service: adFavoriteService}
+	subscriptionHandler := &handlers.SubscriptionHandler{Service: subscriptionService}
 	adConfirmationHandler := &handlers.AdConfirmationHandler{Service: adConfirmationService}
 	workAdHandler := &handlers.WorkAdHandler{Service: workAdService}
 	workAdReviewHandler := &handlers.WorkAdReviewHandler{Service: workAdReviewService}
@@ -293,6 +298,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		adConfirmationRepo:      &adConfirmationRepo,
 		workConfirmationRepo:    &workConfirmationRepo,
 		rentConfirmationRepo:    &rentConfirmationRepo,
+		subscriptionRepo:        &subscriptionRepo,
 
 		// WorkAd блок
 		workAdRepo:             &workAdRepo,
@@ -338,6 +344,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		adResponseHandler:          adResponseHandler,
 		adFavoriteHandler:          adFavoriteHandler,
 		adConfirmationHandler:      adConfirmationHandler,
+		subscriptionHandler:        subscriptionHandler,
 
 		workAdHandler:             workAdHandler,
 		workAdReviewHandler:       workAdReviewHandler,

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -43,6 +43,7 @@ func (app *application) routes() http.Handler {
 	mux.Post("/user/request_reset", authMiddleware.ThenFunc(app.userHandler.RequestPasswordReset))
 	mux.Post("/user/verify_reset_code", authMiddleware.ThenFunc(app.userHandler.VerifyResetCode))
 	mux.Post("/user/reset_password", authMiddleware.ThenFunc(app.userHandler.ResetPassword))
+	mux.Get("/subscription/:user_id", authMiddleware.ThenFunc(app.subscriptionHandler.GetSubscription))
 
 	// Service
 	mux.Post("/service", authMiddleware.ThenFunc(app.serviceHandler.CreateService))                                 //РАБОТАЕТ

--- a/db/migrations/000052_subscription_slots.down.sql
+++ b/db/migrations/000052_subscription_slots.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS subscription_slots;

--- a/db/migrations/000052_subscription_slots.up.sql
+++ b/db/migrations/000052_subscription_slots.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS subscription_slots (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    slots INT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    renews_at TIMESTAMP NOT NULL,
+    provider_subscription_id VARCHAR(100),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_subscription_slots_user (user_id)
+);

--- a/db/migrations/000053_subscription_responses.down.sql
+++ b/db/migrations/000053_subscription_responses.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS subscription_responses;

--- a/db/migrations/000053_subscription_responses.up.sql
+++ b/db/migrations/000053_subscription_responses.up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS subscription_responses (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    packs INT NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    renews_at TIMESTAMP NOT NULL,
+    monthly_quota INT NOT NULL,
+    remaining INT NOT NULL,
+    provider_subscription_id VARCHAR(100),
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX idx_subscription_responses_user (user_id)
+);

--- a/internal/handlers/subscription_handler.go
+++ b/internal/handlers/subscription_handler.go
@@ -1,0 +1,32 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/services"
+)
+
+type SubscriptionHandler struct {
+	Service *services.SubscriptionService
+}
+
+// GetSubscription returns subscription info for specified user.
+func (h *SubscriptionHandler) GetSubscription(w http.ResponseWriter, r *http.Request) {
+	userIDStr := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	profile, err := h.Service.GetProfile(r.Context(), userID)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(profile)
+}

--- a/internal/models/subscription.go
+++ b/internal/models/subscription.go
@@ -1,0 +1,46 @@
+package models
+
+import "time"
+
+// SubscriptionSlots represents monthly executor listing slots.
+type SubscriptionSlots struct {
+	ID                     int        `json:"id"`
+	UserID                 int        `json:"user_id"`
+	Slots                  int        `json:"slots"`
+	Status                 string     `json:"status"`
+	RenewsAt               time.Time  `json:"renews_at"`
+	ProviderSubscriptionID *string    `json:"provider_subscription_id,omitempty"`
+	CreatedAt              time.Time  `json:"created_at"`
+	UpdatedAt              *time.Time `json:"updated_at,omitempty"`
+}
+
+// SubscriptionResponses represents monthly response packs.
+type SubscriptionResponses struct {
+	ID                     int        `json:"id"`
+	UserID                 int        `json:"user_id"`
+	Packs                  int        `json:"packs"`
+	Status                 string     `json:"status"`
+	RenewsAt               time.Time  `json:"renews_at"`
+	MonthlyQuota           int        `json:"monthly_quota"`
+	Remaining              int        `json:"remaining"`
+	ProviderSubscriptionID *string    `json:"provider_subscription_id,omitempty"`
+	CreatedAt              time.Time  `json:"created_at"`
+	UpdatedAt              *time.Time `json:"updated_at,omitempty"`
+}
+
+// SubscriptionProfile aggregates subscription information for profile endpoint.
+type SubscriptionProfile struct {
+	ExecutorListingSlots        int `json:"executor_listing_slots"`
+	ActiveExecutorListingsCount int `json:"active_executor_listings_count"`
+	ResponsePacks               int `json:"response_packs"`
+	MonthlyResponsesQuota       int `json:"monthly_responses_quota"`
+	RemainingResponses          int `json:"remaining_responses"`
+	MonthlyAmount               int `json:"monthly_amount"`
+	Status                      struct {
+		Slots     string `json:"slots"`
+		Responses string `json:"responses"`
+	} `json:"status"`
+	RenewsAt      *time.Time `json:"renews_at,omitempty"`
+	GraceUntil    *time.Time `json:"grace_until,omitempty"`
+	BillingNotice *string    `json:"billing_notice,omitempty"`
+}

--- a/internal/repositories/subscription_repository.go
+++ b/internal/repositories/subscription_repository.go
@@ -1,0 +1,43 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"naimuBack/internal/models"
+)
+
+type SubscriptionRepository struct {
+	DB *sql.DB
+}
+
+func (r *SubscriptionRepository) GetSlots(ctx context.Context, userID int) (models.SubscriptionSlots, error) {
+	query := `SELECT id, user_id, slots, status, renews_at, provider_subscription_id, created_at, updated_at FROM subscription_slots WHERE user_id = ?`
+	var sub models.SubscriptionSlots
+	err := r.DB.QueryRowContext(ctx, query, userID).Scan(&sub.ID, &sub.UserID, &sub.Slots, &sub.Status, &sub.RenewsAt, &sub.ProviderSubscriptionID, &sub.CreatedAt, &sub.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return models.SubscriptionSlots{UserID: userID}, nil
+	}
+	return sub, err
+}
+
+func (r *SubscriptionRepository) GetResponses(ctx context.Context, userID int) (models.SubscriptionResponses, error) {
+	query := `SELECT id, user_id, packs, status, renews_at, monthly_quota, remaining, provider_subscription_id, created_at, updated_at FROM subscription_responses WHERE user_id = ?`
+	var sub models.SubscriptionResponses
+	err := r.DB.QueryRowContext(ctx, query, userID).Scan(&sub.ID, &sub.UserID, &sub.Packs, &sub.Status, &sub.RenewsAt, &sub.MonthlyQuota, &sub.Remaining, &sub.ProviderSubscriptionID, &sub.CreatedAt, &sub.UpdatedAt)
+	if err == sql.ErrNoRows {
+		return models.SubscriptionResponses{UserID: userID}, nil
+	}
+	return sub, err
+}
+
+func (r *SubscriptionRepository) CountActiveExecutorListings(ctx context.Context, userID int) (int, error) {
+	query := `
+        SELECT
+            (SELECT COUNT(*) FROM service WHERE user_id = ? AND status = 'active') +
+            (SELECT COUNT(*) FROM work_ad WHERE user_id = ? AND status = 'active') +
+            (SELECT COUNT(*) FROM rent_ad WHERE user_id = ? AND status = 'active')
+    `
+	var count int
+	err := r.DB.QueryRowContext(ctx, query, userID, userID, userID).Scan(&count)
+	return count, err
+}

--- a/internal/services/subscription_service.go
+++ b/internal/services/subscription_service.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"context"
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+type SubscriptionService struct {
+	Repo *repositories.SubscriptionRepository
+}
+
+func (s *SubscriptionService) GetProfile(ctx context.Context, userID int) (models.SubscriptionProfile, error) {
+	slots, err := s.Repo.GetSlots(ctx, userID)
+	if err != nil {
+		return models.SubscriptionProfile{}, err
+	}
+	responses, err := s.Repo.GetResponses(ctx, userID)
+	if err != nil {
+		return models.SubscriptionProfile{}, err
+	}
+	activeCount, err := s.Repo.CountActiveExecutorListings(ctx, userID)
+	if err != nil {
+		return models.SubscriptionProfile{}, err
+	}
+
+	profile := models.SubscriptionProfile{
+		ExecutorListingSlots:        slots.Slots,
+		ActiveExecutorListingsCount: activeCount,
+		ResponsePacks:               responses.Packs,
+		MonthlyResponsesQuota:       responses.MonthlyQuota,
+		RemainingResponses:          responses.Remaining,
+		MonthlyAmount:               slots.Slots*1000 + responses.Packs*1000,
+	}
+	profile.Status.Slots = slots.Status
+	profile.Status.Responses = responses.Status
+	profile.RenewsAt = &slots.RenewsAt
+	return profile, nil
+}


### PR DESCRIPTION
## Summary
- add subscription models, repository, service, and handler
- expose GET /subscription/:user_id endpoint
- add migrations for subscription slot and response tables

## Testing
- `go test ./...` *(command hung, aborted)*
- `go build ./...` *(command hung, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689dc6b7f8388324a5ef57767ed045f9