### PR TITLE
Add user item listing endpoints

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -55,6 +55,8 @@ type application struct {
 	userResponsesRepo          *repositories.UserResponsesRepository
 	userReviewsHandler         *handlers.UserReviewsHandler
 	userReviewsRepo            *repositories.UserReviewsRepository
+	userItemsHandler           *handlers.UserItemsHandler
+	userItemsRepo              *repositories.UserItemsRepository
 	workHandler                *handlers.WorkHandler
 	workRepo                   *repositories.WorkRepository
 	rentHandler                *handlers.RentHandler
@@ -136,6 +138,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	serviceConfirmationRepo := repositories.ServiceConfirmationRepository{DB: db}
 	userResponsesRepo := repositories.UserResponsesRepository{DB: db}
 	userReviewsRepo := repositories.UserReviewsRepository{DB: db}
+	userItemsRepo := repositories.UserItemsRepository{DB: db}
 	workRepo := repositories.WorkRepository{DB: db}
 	rentRepo := repositories.RentRepository{DB: db}
 	workReviewRepo := repositories.WorkReviewRepository{DB: db}
@@ -180,6 +183,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	serviceConfirmationService := &services.ServiceConfirmationService{ConfirmationRepo: &serviceConfirmationRepo}
 	userResponsesService := &services.UserResponsesService{ResponsesRepo: &userResponsesRepo}
 	userReviewsService := &services.UserReviewsService{ReviewsRepo: &userReviewsRepo}
+	userItemsService := &services.UserItemsService{ItemsRepo: &userItemsRepo}
 	workService := &services.WorkService{WorkRepo: &workRepo}
 	rentService := &services.RentService{RentRepo: &rentRepo}
 	workReviewService := &services.WorkReviewService{WorkReviewsRepo: &workReviewRepo}
@@ -236,6 +240,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	serviceConfirmationHandler := &handlers.ServiceConfirmationHandler{Service: serviceConfirmationService}
 	userResponsesHandler := &handlers.UserResponsesHandler{Service: userResponsesService}
 	userReviewsHandler := &handlers.UserReviewsHandler{Service: userReviewsService}
+	userItemsHandler := &handlers.UserItemsHandler{Service: userItemsService}
 	workHandler := &handlers.WorkHandler{Service: workService}
 	rentHandler := &handlers.RentHandler{Service: rentService}
 	workReviewHandler := &handlers.WorkReviewHandler{Service: workReviewService}
@@ -300,6 +305,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		serviceConfirmationRepo: &serviceConfirmationRepo,
 		userResponsesRepo:       &userResponsesRepo,
 		userReviewsRepo:         &userReviewsRepo,
+		userItemsRepo:           &userItemsRepo,
 		workRepo:                &workRepo,
 		rentRepo:                &rentRepo,
 		workReviewRepo:          &workReviewRepo,
@@ -348,6 +354,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		serviceConfirmationHandler: serviceConfirmationHandler,
 		userResponsesHandler:       userResponsesHandler,
 		userReviewsHandler:         userReviewsHandler,
+		userItemsHandler:           userItemsHandler,
 		workHandler:                workHandler,
 		rentHandler:                rentHandler,
 		workReviewHandler:          workReviewHandler,

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -47,6 +47,9 @@ func (app *application) routes() http.Handler {
 	mux.Post("/robokassa/pay", standardMiddleware.ThenFunc(app.robokassaHandler.CreatePayment))
 	mux.Post("/robokassa/result", standardMiddleware.ThenFunc(app.robokassaHandler.Result))
 
+	mux.Get("/user/posts/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetPostsByUserID))
+	mux.Get("/user/ads/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetAdsByUserID))
+
 	// Service
 	mux.Post("/service", authMiddleware.ThenFunc(app.serviceHandler.CreateService))                                 //РАБОТАЕТ
 	mux.Get("/service/get", standardMiddleware.ThenFunc(app.serviceHandler.GetServices))                            //РАБОТАЕТ

--- a/internal/handlers/user_items_handler.go
+++ b/internal/handlers/user_items_handler.go
@@ -1,0 +1,52 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/services"
+)
+
+// UserItemsHandler handles HTTP requests for user items.
+type UserItemsHandler struct {
+	Service *services.UserItemsService
+}
+
+// GetPostsByUserID returns all services, works and rents for the specified user.
+func (h *UserItemsHandler) GetPostsByUserID(w http.ResponseWriter, r *http.Request) {
+	userIDStr := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	items, err := h.Service.GetServiceWorkRentByUserID(r.Context(), userID)
+	if err != nil {
+		http.Error(w, "failed to get items", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(items)
+}
+
+// GetAdsByUserID returns all ads, work_ads and rent_ads for the specified user.
+func (h *UserItemsHandler) GetAdsByUserID(w http.ResponseWriter, r *http.Request) {
+	userIDStr := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	items, err := h.Service.GetAdWorkAdRentAdByUserID(r.Context(), userID)
+	if err != nil {
+		http.Error(w, "failed to get items", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(items)
+}

--- a/internal/models/user_items.go
+++ b/internal/models/user_items.go
@@ -1,0 +1,13 @@
+package models
+
+import "time"
+
+// UserItem represents a generic user-owned item across different entities.
+type UserItem struct {
+	ID          int       `json:"id"`
+	Name        string    `json:"name"`
+	Price       float64   `json:"price"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+	Type        string    `json:"type"`
+}

--- a/internal/repositories/user_items_repository.go
+++ b/internal/repositories/user_items_repository.go
@@ -1,0 +1,65 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+// UserItemsRepository retrieves user items across multiple entities.
+type UserItemsRepository struct {
+	DB *sql.DB
+}
+
+// GetServiceWorkRentByUserID returns service, work and rent items owned by the user ordered by creation time.
+func (r *UserItemsRepository) GetServiceWorkRentByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
+	query := `
+    SELECT id, name, price, description, created_at, 'service' AS type FROM service WHERE user_id = ?
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'work' AS type FROM work WHERE user_id = ?
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'rent' AS type FROM rent WHERE user_id = ?
+    ORDER BY created_at DESC`
+	rows, err := r.DB.QueryContext(ctx, query, userID, userID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []models.UserItem
+	for rows.Next() {
+		var item models.UserItem
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Type); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}
+
+// GetAdWorkAdRentAdByUserID returns ad, work_ad and rent_ad items owned by the user ordered by creation time.
+func (r *UserItemsRepository) GetAdWorkAdRentAdByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
+	query := `
+    SELECT id, name, price, description, created_at, 'ad' AS type FROM ad WHERE user_id = ?
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'work_ad' AS type FROM work_ad WHERE user_id = ?
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'rent_ad' AS type FROM rent_ad WHERE user_id = ?
+    ORDER BY created_at DESC`
+	rows, err := r.DB.QueryContext(ctx, query, userID, userID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []models.UserItem
+	for rows.Next() {
+		var item models.UserItem
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Type); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/services/user_items_service.go
+++ b/internal/services/user_items_service.go
@@ -1,0 +1,23 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+// UserItemsService provides business logic for retrieving user items.
+type UserItemsService struct {
+	ItemsRepo *repositories.UserItemsRepository
+}
+
+// GetServiceWorkRentByUserID fetches service, work and rent items for the user.
+func (s *UserItemsService) GetServiceWorkRentByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
+	return s.ItemsRepo.GetServiceWorkRentByUserID(ctx, userID)
+}
+
+// GetAdWorkAdRentAdByUserID fetches ad, work_ad and rent_ad items for the user.
+func (s *UserItemsService) GetAdWorkAdRentAdByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
+	return s.ItemsRepo.GetAdWorkAdRentAdByUserID(ctx, userID)
+}


### PR DESCRIPTION
## Summary
- add user item model and repository for querying items across services, works and rents
- expose `/user/posts/:user_id` and `/user/ads/:user_id` endpoints to fetch items sorted by creation time
- wire new service and handler into application initializer and routes

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e96635c588324b01c9903d53d0d1e