### PR TITLE
Make price filter optional in filtered endpoints

### DIFF
--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -314,14 +314,20 @@ func (r *AdRepository) GetAdByUserID(ctx context.Context, userID int) ([]models.
 
 func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterAdRequest) ([]models.FilteredAd, error) {
 	query := `
-       SELECT
-               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-               s.id, s.name, s.price, s.description
-       FROM ad s
-       JOIN users u ON s.user_id = u.id
-       WHERE s.price BETWEEN ? AND ?
+      SELECT
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+              s.id, s.name, s.price, s.description
+      FROM ad s
+      JOIN users u ON s.user_id = u.id
+      WHERE 1=1
 `
-	args := []interface{}{req.PriceFrom, req.PriceTo}
+	args := []interface{}{}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {
@@ -439,10 +445,16 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
        FROM ad s
        JOIN users u ON s.user_id = u.id
        LEFT JOIN ad_favorites sf ON sf.ad_id = s.id AND sf.user_id = ?
-       WHERE s.price BETWEEN ? AND ?
+       WHERE 1=1
 `
 
-	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
+	args := []interface{}{userID}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -308,14 +308,20 @@ func (r *RentAdRepository) GetRentsAdByUserID(ctx context.Context, userID int) (
 
 func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req models.FilterRentAdRequest) ([]models.FilteredRentAd, error) {
 	query := `
-       SELECT
-               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-               s.id, s.name, s.price, s.description
-       FROM rent_ad s
-       JOIN users u ON s.user_id = u.id
-       WHERE s.price BETWEEN ? AND ?
+      SELECT
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+              s.id, s.name, s.price, s.description
+      FROM rent_ad s
+      JOIN users u ON s.user_id = u.id
+      WHERE 1=1
 `
-	args := []interface{}{req.PriceFrom, req.PriceTo}
+	args := []interface{}{}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {
@@ -433,10 +439,16 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
        FROM rent_ad s
        JOIN users u ON s.user_id = u.id
        LEFT JOIN rent_ad_favorites sf ON sf.rent_ad_id = s.id AND sf.user_id = ?
-       WHERE s.price BETWEEN ? AND ?
+       WHERE 1=1
 `
 
-	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
+	args := []interface{}{userID}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -308,14 +308,20 @@ func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]mo
 
 func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.FilterRentRequest) ([]models.FilteredRent, error) {
 	query := `
-       SELECT
-               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-               s.id, s.name, s.price, s.description
-       FROM rent s
-       JOIN users u ON s.user_id = u.id
-       WHERE s.price BETWEEN ? AND ?
+      SELECT
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+              s.id, s.name, s.price, s.description
+      FROM rent s
+      JOIN users u ON s.user_id = u.id
+      WHERE 1=1
 `
-	args := []interface{}{req.PriceFrom, req.PriceTo}
+	args := []interface{}{}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {
@@ -433,10 +439,16 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
        FROM rent s
        JOIN users u ON s.user_id = u.id
        LEFT JOIN rent_favorites sf ON sf.rent_id = s.id AND sf.user_id = ?
-       WHERE s.price BETWEEN ? AND ?
+       WHERE 1=1
 `
 
-	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
+	args := []interface{}{userID}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -315,14 +315,20 @@ func (r *ServiceRepository) GetServicesByUserID(ctx context.Context, userID int)
 
 func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req models.FilterServicesRequest) ([]models.FilteredService, error) {
 	query := `
-       SELECT
-               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-               s.id, s.name, s.price, s.description
-       FROM service s
-       JOIN users u ON s.user_id = u.id
-       WHERE s.price BETWEEN ? AND ?
+      SELECT
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+              s.id, s.name, s.price, s.description
+      FROM service s
+      JOIN users u ON s.user_id = u.id
+      WHERE 1=1
 `
-	args := []interface{}{req.PriceFrom, req.PriceTo}
+	args := []interface{}{}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -314,14 +314,20 @@ func (r *WorkAdRepository) GetWorksAdByUserID(ctx context.Context, userID int) (
 
 func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req models.FilterWorkAdRequest) ([]models.FilteredWorkAd, error) {
 	query := `
-       SELECT
-               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-               s.id, s.name, s.price, s.description
-       FROM work_ad s
-       JOIN users u ON s.user_id = u.id
-       WHERE s.price BETWEEN ? AND ?
+      SELECT
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+              s.id, s.name, s.price, s.description
+      FROM work_ad s
+      JOIN users u ON s.user_id = u.id
+      WHERE 1=1
 `
-	args := []interface{}{req.PriceFrom, req.PriceTo}
+	args := []interface{}{}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {
@@ -439,10 +445,16 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
        FROM work_ad s
        JOIN users u ON s.user_id = u.id
        LEFT JOIN work_ad_favorites sf ON sf.work_ad_id = s.id AND sf.user_id = ?
-       WHERE s.price BETWEEN ? AND ?
+       WHERE 1=1
 `
 
-	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
+	args := []interface{}{userID}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -324,14 +324,20 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 
 func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.FilterWorkRequest) ([]models.FilteredWork, error) {
 	query := `
-       SELECT
-               u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-               s.id, s.name, s.price, s.description
-       FROM work s
-       JOIN users u ON s.user_id = u.id
-       WHERE s.price BETWEEN ? AND ?
+      SELECT
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
+              s.id, s.name, s.price, s.description
+      FROM work s
+      JOIN users u ON s.user_id = u.id
+      WHERE 1=1
 `
-	args := []interface{}{req.PriceFrom, req.PriceTo}
+	args := []interface{}{}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {
@@ -449,10 +455,16 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
        FROM work s
        JOIN users u ON s.user_id = u.id
        LEFT JOIN work_favorites sf ON sf.work_id = s.id AND sf.user_id = ?
-       WHERE s.price BETWEEN ? AND ?
+       WHERE 1=1
 `
 
-	args := []interface{}{userID, req.PriceFrom, req.PriceTo}
+	args := []interface{}{userID}
+
+	// Price filter (optional)
+	if req.PriceFrom > 0 && req.PriceTo > 0 {
+		query += " AND s.price BETWEEN ? AND ?"
+		args = append(args, req.PriceFrom, req.PriceTo)
+	}
 
 	// Category
 	if len(req.CategoryIDs) > 0 {


### PR DESCRIPTION
## Summary
- allow filtered endpoints to omit price range by default
- conditionally apply `s.price BETWEEN` only when both price_from and price_to provided

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689f3291f9b88324ab64921399deef9f