### PR TITLE
feat: add user order history endpoint

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -49,6 +49,7 @@ func (app *application) routes() http.Handler {
 
 	mux.Get("/user/posts/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetPostsByUserID))
 	mux.Get("/user/ads/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetAdsByUserID))
+	mux.Get("/user/orders/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetOrderHistoryByUserID))
 
 	mux.Get("/ads", standardMiddleware.ThenFunc(app.adHandler.GetAds))
 

--- a/internal/handlers/user_items_handler.go
+++ b/internal/handlers/user_items_handler.go
@@ -50,3 +50,22 @@ func (h *UserItemsHandler) GetAdsByUserID(w http.ResponseWriter, r *http.Request
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(items)
 }
+
+// GetOrderHistoryByUserID returns all completed services, works, rents and ads for the specified user.
+func (h *UserItemsHandler) GetOrderHistoryByUserID(w http.ResponseWriter, r *http.Request) {
+	userIDStr := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	items, err := h.Service.GetOrderHistoryByUserID(r.Context(), userID)
+	if err != nil {
+		http.Error(w, "failed to get items", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(items)
+}

--- a/internal/repositories/user_items_repository.go
+++ b/internal/repositories/user_items_repository.go
@@ -63,3 +63,35 @@ func (r *UserItemsRepository) GetAdWorkAdRentAdByUserID(ctx context.Context, use
 	}
 	return items, rows.Err()
 }
+
+// GetOrderHistoryByUserID returns completed service, work, rent, ad, work_ad and rent_ad items for the user ordered by creation time.
+func (r *UserItemsRepository) GetOrderHistoryByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
+	query := `
+    SELECT id, name, price, description, created_at, 'service' AS type FROM service WHERE user_id = ? AND status = 'done'
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'work' AS type FROM work WHERE user_id = ? AND status = 'done'
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'rent' AS type FROM rent WHERE user_id = ? AND status = 'done'
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'ad' AS type FROM ad WHERE user_id = ? AND status = 'done'
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'work_ad' AS type FROM work_ad WHERE user_id = ? AND status = 'done'
+    UNION ALL
+    SELECT id, name, price, description, created_at, 'rent_ad' AS type FROM rent_ad WHERE user_id = ? AND status = 'done'
+    ORDER BY created_at DESC`
+	rows, err := r.DB.QueryContext(ctx, query, userID, userID, userID, userID, userID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []models.UserItem
+	for rows.Next() {
+		var item models.UserItem
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Type); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/services/user_items_service.go
+++ b/internal/services/user_items_service.go
@@ -21,3 +21,8 @@ func (s *UserItemsService) GetServiceWorkRentByUserID(ctx context.Context, userI
 func (s *UserItemsService) GetAdWorkAdRentAdByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
 	return s.ItemsRepo.GetAdWorkAdRentAdByUserID(ctx, userID)
 }
+
+// GetOrderHistoryByUserID fetches completed service, work, rent, ad, work_ad and rent_ad items for the user.
+func (s *UserItemsService) GetOrderHistoryByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
+	return s.ItemsRepo.GetOrderHistoryByUserID(ctx, userID)
+}


### PR DESCRIPTION
## Summary
- add repository method to fetch completed items for a user
- expose service and handler to return order history including ads
- register `/user/orders/:user_id` route

## Testing
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a21d9d9de48324bc3ef1aa030d627b