### PR TITLE
Add complaints for ad, work, rent and ad variants

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -47,6 +47,16 @@ type application struct {
 	db                         *sql.DB
 	complaintHandler           *handlers.ComplaintHandler
 	complaintRepo              *repositories.ComplaintRepository
+	adComplaintHandler         *handlers.AdComplaintHandler
+	adComplaintRepo            *repositories.AdComplaintRepository
+	workComplaintHandler       *handlers.WorkComplaintHandler
+	workComplaintRepo          *repositories.WorkComplaintRepository
+	workAdComplaintHandler     *handlers.WorkAdComplaintHandler
+	workAdComplaintRepo        *repositories.WorkAdComplaintRepository
+	rentComplaintHandler       *handlers.RentComplaintHandler
+	rentComplaintRepo          *repositories.RentComplaintRepository
+	rentAdComplaintHandler     *handlers.RentAdComplaintHandler
+	rentAdComplaintRepo        *repositories.RentAdComplaintRepository
 	serviceResponseHandler     *handlers.ServiceResponseHandler
 	serviceResponseRepo        *repositories.ServiceResponseRepository
 	serviceConfirmationHandler *handlers.ServiceConfirmationHandler
@@ -132,6 +142,11 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	workSubcategoryRepo := repositories.WorkSubcategoryRepository{DB: db}
 	cityRepo := repositories.CityRepository{DB: db}
 	complaintRepo := repositories.ComplaintRepository{DB: db}
+	adComplaintRepo := repositories.AdComplaintRepository{DB: db}
+	workComplaintRepo := repositories.WorkComplaintRepository{DB: db}
+	workAdComplaintRepo := repositories.WorkAdComplaintRepository{DB: db}
+	rentComplaintRepo := repositories.RentComplaintRepository{DB: db}
+	rentAdComplaintRepo := repositories.RentAdComplaintRepository{DB: db}
 	chatRepo := repositories.ChatRepository{Db: db}
 	messageRepo := repositories.MessageRepository{Db: db}
 	serviceResponseRepo := repositories.ServiceResponseRepository{DB: db}
@@ -179,6 +194,11 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	workSubcategoryService := services.WorkSubcategoryService{SubcategoryRepo: &workSubcategoryRepo}
 	cityService := services.CityService{CityRepo: &cityRepo}
 	complaintService := services.ComplaintService{ComplaintRepo: &complaintRepo}
+	adComplaintService := services.AdComplaintService{ComplaintRepo: &adComplaintRepo}
+	workComplaintService := services.WorkComplaintService{ComplaintRepo: &workComplaintRepo}
+	workAdComplaintService := services.WorkAdComplaintService{ComplaintRepo: &workAdComplaintRepo}
+	rentComplaintService := services.RentComplaintService{ComplaintRepo: &rentComplaintRepo}
+	rentAdComplaintService := services.RentAdComplaintService{ComplaintRepo: &rentAdComplaintRepo}
 	serviceResponseService := &services.ServiceResponseService{ServiceResponseRepo: &serviceResponseRepo, ServiceRepo: &serviceRepo, ChatRepo: &chatRepo, ConfirmationRepo: &serviceConfirmationRepo, MessageRepo: &messageRepo}
 	serviceConfirmationService := &services.ServiceConfirmationService{ConfirmationRepo: &serviceConfirmationRepo}
 	userResponsesService := &services.UserResponsesService{ResponsesRepo: &userResponsesRepo}
@@ -236,6 +256,11 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	workSubcategoryHandler := handlers.WorkSubcategoryHandler{Service: &workSubcategoryService}
 	cityHandler := handlers.CityHandler{Service: &cityService}
 	complaintHandler := &handlers.ComplaintHandler{Service: &complaintService}
+	adComplaintHandler := &handlers.AdComplaintHandler{Service: &adComplaintService}
+	workComplaintHandler := &handlers.WorkComplaintHandler{Service: &workComplaintService}
+	workAdComplaintHandler := &handlers.WorkAdComplaintHandler{Service: &workAdComplaintService}
+	rentComplaintHandler := &handlers.RentComplaintHandler{Service: &rentComplaintService}
+	rentAdComplaintHandler := &handlers.RentAdComplaintHandler{Service: &rentAdComplaintService}
 	serviceResponseHandler := &handlers.ServiceResponseHandler{Service: serviceResponseService}
 	serviceConfirmationHandler := &handlers.ServiceConfirmationHandler{Service: serviceConfirmationService}
 	userResponsesHandler := &handlers.UserResponsesHandler{Service: userResponsesService}
@@ -301,6 +326,11 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		workSubcategoryRepo:     workSubcategoryRepo, // value
 		cityRepo:                cityRepo,            // value
 		complaintRepo:           &complaintRepo,
+		adComplaintRepo:         &adComplaintRepo,
+		workComplaintRepo:       &workComplaintRepo,
+		workAdComplaintRepo:     &workAdComplaintRepo,
+		rentComplaintRepo:       &rentComplaintRepo,
+		rentAdComplaintRepo:     &rentAdComplaintRepo,
 		serviceResponseRepo:     &serviceResponseRepo,
 		serviceConfirmationRepo: &serviceConfirmationRepo,
 		userResponsesRepo:       &userResponsesRepo,
@@ -350,6 +380,11 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		workSubcategoryHandler:     workSubcategoryHandler,
 		cityHandler:                cityHandler,
 		complaintHandler:           complaintHandler,
+		adComplaintHandler:         adComplaintHandler,
+		workComplaintHandler:       workComplaintHandler,
+		workAdComplaintHandler:     workAdComplaintHandler,
+		rentComplaintHandler:       rentComplaintHandler,
+		rentAdComplaintHandler:     rentAdComplaintHandler,
 		serviceResponseHandler:     serviceResponseHandler,
 		serviceConfirmationHandler: serviceConfirmationHandler,
 		userResponsesHandler:       userResponsesHandler,

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -162,6 +162,36 @@ func (app *application) routes() http.Handler {
 	mux.Del("/complaints/:id", authMiddleware.ThenFunc(app.complaintHandler.DeleteComplaintByID))
 	mux.Get("/complaints", standardMiddleware.ThenFunc(app.complaintHandler.GetAllComplaints))
 
+	// Ad Complaints
+	mux.Post("/ad_complaint", authMiddleware.ThenFunc(app.adComplaintHandler.CreateAdComplaint))
+	mux.Get("/ad_complaint/:ad_id", standardMiddleware.ThenFunc(app.adComplaintHandler.GetComplaintsByAdID))
+	mux.Del("/ad_complaint/:id", authMiddleware.ThenFunc(app.adComplaintHandler.DeleteAdComplaintByID))
+	mux.Get("/ad_complaints", standardMiddleware.ThenFunc(app.adComplaintHandler.GetAllAdComplaints))
+
+	// Work Complaints
+	mux.Post("/work_complaint", authMiddleware.ThenFunc(app.workComplaintHandler.CreateWorkComplaint))
+	mux.Get("/work_complaint/:work_id", standardMiddleware.ThenFunc(app.workComplaintHandler.GetComplaintsByWorkID))
+	mux.Del("/work_complaint/:id", authMiddleware.ThenFunc(app.workComplaintHandler.DeleteWorkComplaintByID))
+	mux.Get("/work_complaints", standardMiddleware.ThenFunc(app.workComplaintHandler.GetAllWorkComplaints))
+
+	// Work Ad Complaints
+	mux.Post("/work_ad_complaint", authMiddleware.ThenFunc(app.workAdComplaintHandler.CreateWorkAdComplaint))
+	mux.Get("/work_ad_complaint/:work_ad_id", standardMiddleware.ThenFunc(app.workAdComplaintHandler.GetComplaintsByWorkAdID))
+	mux.Del("/work_ad_complaint/:id", authMiddleware.ThenFunc(app.workAdComplaintHandler.DeleteWorkAdComplaintByID))
+	mux.Get("/work_ad_complaints", standardMiddleware.ThenFunc(app.workAdComplaintHandler.GetAllWorkAdComplaints))
+
+	// Rent Complaints
+	mux.Post("/rent_complaint", authMiddleware.ThenFunc(app.rentComplaintHandler.CreateRentComplaint))
+	mux.Get("/rent_complaint/:rent_id", standardMiddleware.ThenFunc(app.rentComplaintHandler.GetComplaintsByRentID))
+	mux.Del("/rent_complaint/:id", authMiddleware.ThenFunc(app.rentComplaintHandler.DeleteRentComplaintByID))
+	mux.Get("/rent_complaints", standardMiddleware.ThenFunc(app.rentComplaintHandler.GetAllRentComplaints))
+
+	// Rent Ad Complaints
+	mux.Post("/rent_ad_complaint", authMiddleware.ThenFunc(app.rentAdComplaintHandler.CreateRentAdComplaint))
+	mux.Get("/rent_ad_complaint/:rent_ad_id", standardMiddleware.ThenFunc(app.rentAdComplaintHandler.GetComplaintsByRentAdID))
+	mux.Del("/rent_ad_complaint/:id", authMiddleware.ThenFunc(app.rentAdComplaintHandler.DeleteRentAdComplaintByID))
+	mux.Get("/rent_ad_complaints", standardMiddleware.ThenFunc(app.rentAdComplaintHandler.GetAllRentAdComplaints))
+
 	// Service Response
 	mux.Post("/responses", authMiddleware.ThenFunc(app.serviceResponseHandler.CreateServiceResponse))
 	mux.Get("/responses/:user_id", authMiddleware.ThenFunc(app.userResponsesHandler.GetResponsesByUserID))

--- a/db/migrations/000054_ad_complaint.down.sql
+++ b/db/migrations/000054_ad_complaint.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS ad_complaints;
+use naimudb;

--- a/db/migrations/000054_ad_complaint.up.sql
+++ b/db/migrations/000054_ad_complaint.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE ad_complaints
+(
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    ad_id       INT  NOT NULL,
+    user_id     INT  NOT NULL,
+    description TEXT NOT NULL,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (ad_id) REFERENCES ad (id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+use naimudb;

--- a/db/migrations/000055_work_complaint.down.sql
+++ b/db/migrations/000055_work_complaint.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS work_complaints;
+use naimudb;

--- a/db/migrations/000055_work_complaint.up.sql
+++ b/db/migrations/000055_work_complaint.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE work_complaints
+(
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    work_id     INT  NOT NULL,
+    user_id     INT  NOT NULL,
+    description TEXT NOT NULL,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (work_id) REFERENCES work (id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+use naimudb;

--- a/db/migrations/000056_work_ad_complaint.down.sql
+++ b/db/migrations/000056_work_ad_complaint.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS work_ad_complaints;
+use naimudb;

--- a/db/migrations/000056_work_ad_complaint.up.sql
+++ b/db/migrations/000056_work_ad_complaint.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE work_ad_complaints
+(
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    work_ad_id  INT  NOT NULL,
+    user_id     INT  NOT NULL,
+    description TEXT NOT NULL,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (work_ad_id) REFERENCES work_ad (id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+use naimudb;

--- a/db/migrations/000057_rent_complaint.down.sql
+++ b/db/migrations/000057_rent_complaint.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS rent_complaints;
+use naimudb;

--- a/db/migrations/000057_rent_complaint.up.sql
+++ b/db/migrations/000057_rent_complaint.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE rent_complaints
+(
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    rent_id     INT  NOT NULL,
+    user_id     INT  NOT NULL,
+    description TEXT NOT NULL,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (rent_id) REFERENCES rent (id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+use naimudb;

--- a/db/migrations/000058_rent_ad_complaint.down.sql
+++ b/db/migrations/000058_rent_ad_complaint.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS rent_ad_complaints;
+use naimudb;

--- a/db/migrations/000058_rent_ad_complaint.up.sql
+++ b/db/migrations/000058_rent_ad_complaint.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE rent_ad_complaints
+(
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    rent_ad_id  INT  NOT NULL,
+    user_id     INT  NOT NULL,
+    description TEXT NOT NULL,
+    created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (rent_ad_id) REFERENCES rent_ad (id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+);
+use naimudb;

--- a/internal/handlers/ad_complaint_handler.go
+++ b/internal/handlers/ad_complaint_handler.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/services"
+)
+
+type AdComplaintHandler struct {
+	Service *services.AdComplaintService
+}
+
+func (h *AdComplaintHandler) CreateAdComplaint(w http.ResponseWriter, r *http.Request) {
+	var c models.AdComplaint
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		http.Error(w, "Invalid input", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.CreateAdComplaint(r.Context(), c); err != nil {
+		log.Printf("CreateAdComplaint error: %v", err)
+		http.Error(w, "Failed to create complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *AdComplaintHandler) GetComplaintsByAdID(w http.ResponseWriter, r *http.Request) {
+	adID, err := strconv.Atoi(r.URL.Query().Get(":ad_id"))
+	if err != nil {
+		http.Error(w, "Invalid ad_id", http.StatusBadRequest)
+		return
+	}
+	complaints, err := h.Service.GetComplaintsByAdID(r.Context(), adID)
+	if err != nil {
+		log.Printf("GetComplaintsByAdID error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}
+
+func (h *AdComplaintHandler) DeleteAdComplaintByID(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get(":id")
+	if idStr == "" {
+		http.Error(w, "Invalid ID", http.StatusBadRequest)
+		return
+	}
+	id, _ := strconv.Atoi(idStr)
+	if err := h.Service.DeleteAdComplaintByID(r.Context(), id); err != nil {
+		log.Printf("DeleteAdComplaint error: %v", err)
+		http.Error(w, "Failed to delete complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *AdComplaintHandler) GetAllAdComplaints(w http.ResponseWriter, r *http.Request) {
+	complaints, err := h.Service.GetAllAdComplaints(r.Context())
+	if err != nil {
+		log.Printf("GetAllAdComplaints error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}

--- a/internal/handlers/rent_ad_complaint_handler.go
+++ b/internal/handlers/rent_ad_complaint_handler.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/services"
+)
+
+type RentAdComplaintHandler struct {
+	Service *services.RentAdComplaintService
+}
+
+func (h *RentAdComplaintHandler) CreateRentAdComplaint(w http.ResponseWriter, r *http.Request) {
+	var c models.RentAdComplaint
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		http.Error(w, "Invalid input", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.CreateRentAdComplaint(r.Context(), c); err != nil {
+		log.Printf("CreateRentAdComplaint error: %v", err)
+		http.Error(w, "Failed to create complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *RentAdComplaintHandler) GetComplaintsByRentAdID(w http.ResponseWriter, r *http.Request) {
+	rentAdID, err := strconv.Atoi(r.URL.Query().Get(":rent_ad_id"))
+	if err != nil {
+		http.Error(w, "Invalid rent_ad_id", http.StatusBadRequest)
+		return
+	}
+	complaints, err := h.Service.GetComplaintsByRentAdID(r.Context(), rentAdID)
+	if err != nil {
+		log.Printf("GetComplaintsByRentAdID error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}
+
+func (h *RentAdComplaintHandler) DeleteRentAdComplaintByID(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get(":id")
+	if idStr == "" {
+		http.Error(w, "Invalid ID", http.StatusBadRequest)
+		return
+	}
+	id, _ := strconv.Atoi(idStr)
+	if err := h.Service.DeleteRentAdComplaintByID(r.Context(), id); err != nil {
+		log.Printf("DeleteRentAdComplaint error: %v", err)
+		http.Error(w, "Failed to delete complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *RentAdComplaintHandler) GetAllRentAdComplaints(w http.ResponseWriter, r *http.Request) {
+	complaints, err := h.Service.GetAllRentAdComplaints(r.Context())
+	if err != nil {
+		log.Printf("GetAllRentAdComplaints error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}

--- a/internal/handlers/rent_complaint_handler.go
+++ b/internal/handlers/rent_complaint_handler.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/services"
+)
+
+type RentComplaintHandler struct {
+	Service *services.RentComplaintService
+}
+
+func (h *RentComplaintHandler) CreateRentComplaint(w http.ResponseWriter, r *http.Request) {
+	var c models.RentComplaint
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		http.Error(w, "Invalid input", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.CreateRentComplaint(r.Context(), c); err != nil {
+		log.Printf("CreateRentComplaint error: %v", err)
+		http.Error(w, "Failed to create complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *RentComplaintHandler) GetComplaintsByRentID(w http.ResponseWriter, r *http.Request) {
+	rentID, err := strconv.Atoi(r.URL.Query().Get(":rent_id"))
+	if err != nil {
+		http.Error(w, "Invalid rent_id", http.StatusBadRequest)
+		return
+	}
+	complaints, err := h.Service.GetComplaintsByRentID(r.Context(), rentID)
+	if err != nil {
+		log.Printf("GetComplaintsByRentID error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}
+
+func (h *RentComplaintHandler) DeleteRentComplaintByID(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get(":id")
+	if idStr == "" {
+		http.Error(w, "Invalid ID", http.StatusBadRequest)
+		return
+	}
+	id, _ := strconv.Atoi(idStr)
+	if err := h.Service.DeleteRentComplaintByID(r.Context(), id); err != nil {
+		log.Printf("DeleteRentComplaint error: %v", err)
+		http.Error(w, "Failed to delete complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *RentComplaintHandler) GetAllRentComplaints(w http.ResponseWriter, r *http.Request) {
+	complaints, err := h.Service.GetAllRentComplaints(r.Context())
+	if err != nil {
+		log.Printf("GetAllRentComplaints error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}

--- a/internal/handlers/work_ad_complaint_handler.go
+++ b/internal/handlers/work_ad_complaint_handler.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/services"
+)
+
+type WorkAdComplaintHandler struct {
+	Service *services.WorkAdComplaintService
+}
+
+func (h *WorkAdComplaintHandler) CreateWorkAdComplaint(w http.ResponseWriter, r *http.Request) {
+	var c models.WorkAdComplaint
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		http.Error(w, "Invalid input", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.CreateWorkAdComplaint(r.Context(), c); err != nil {
+		log.Printf("CreateWorkAdComplaint error: %v", err)
+		http.Error(w, "Failed to create complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *WorkAdComplaintHandler) GetComplaintsByWorkAdID(w http.ResponseWriter, r *http.Request) {
+	workAdID, err := strconv.Atoi(r.URL.Query().Get(":work_ad_id"))
+	if err != nil {
+		http.Error(w, "Invalid work_ad_id", http.StatusBadRequest)
+		return
+	}
+	complaints, err := h.Service.GetComplaintsByWorkAdID(r.Context(), workAdID)
+	if err != nil {
+		log.Printf("GetComplaintsByWorkAdID error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}
+
+func (h *WorkAdComplaintHandler) DeleteWorkAdComplaintByID(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get(":id")
+	if idStr == "" {
+		http.Error(w, "Invalid ID", http.StatusBadRequest)
+		return
+	}
+	id, _ := strconv.Atoi(idStr)
+	if err := h.Service.DeleteWorkAdComplaintByID(r.Context(), id); err != nil {
+		log.Printf("DeleteWorkAdComplaint error: %v", err)
+		http.Error(w, "Failed to delete complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *WorkAdComplaintHandler) GetAllWorkAdComplaints(w http.ResponseWriter, r *http.Request) {
+	complaints, err := h.Service.GetAllWorkAdComplaints(r.Context())
+	if err != nil {
+		log.Printf("GetAllWorkAdComplaints error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}

--- a/internal/handlers/work_complaint_handler.go
+++ b/internal/handlers/work_complaint_handler.go
@@ -1,0 +1,71 @@
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/services"
+)
+
+type WorkComplaintHandler struct {
+	Service *services.WorkComplaintService
+}
+
+func (h *WorkComplaintHandler) CreateWorkComplaint(w http.ResponseWriter, r *http.Request) {
+	var c models.WorkComplaint
+	if err := json.NewDecoder(r.Body).Decode(&c); err != nil {
+		http.Error(w, "Invalid input", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.CreateWorkComplaint(r.Context(), c); err != nil {
+		log.Printf("CreateWorkComplaint error: %v", err)
+		http.Error(w, "Failed to create complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+}
+
+func (h *WorkComplaintHandler) GetComplaintsByWorkID(w http.ResponseWriter, r *http.Request) {
+	workID, err := strconv.Atoi(r.URL.Query().Get(":work_id"))
+	if err != nil {
+		http.Error(w, "Invalid work_id", http.StatusBadRequest)
+		return
+	}
+	complaints, err := h.Service.GetComplaintsByWorkID(r.Context(), workID)
+	if err != nil {
+		log.Printf("GetComplaintsByWorkID error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}
+
+func (h *WorkComplaintHandler) DeleteWorkComplaintByID(w http.ResponseWriter, r *http.Request) {
+	idStr := r.URL.Query().Get(":id")
+	if idStr == "" {
+		http.Error(w, "Invalid ID", http.StatusBadRequest)
+		return
+	}
+	id, _ := strconv.Atoi(idStr)
+	if err := h.Service.DeleteWorkComplaintByID(r.Context(), id); err != nil {
+		log.Printf("DeleteWorkComplaint error: %v", err)
+		http.Error(w, "Failed to delete complaint", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *WorkComplaintHandler) GetAllWorkComplaints(w http.ResponseWriter, r *http.Request) {
+	complaints, err := h.Service.GetAllWorkComplaints(r.Context())
+	if err != nil {
+		log.Printf("GetAllWorkComplaints error: %v", err)
+		http.Error(w, "Failed to get complaints", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(complaints)
+}

--- a/internal/models/ad_complaint.go
+++ b/internal/models/ad_complaint.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type AdComplaint struct {
+	ID          int       `json:"id"`
+	AdID        int       `json:"ad_id"`
+	UserID      int       `json:"user_id"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/models/rent_ad_complaint.go
+++ b/internal/models/rent_ad_complaint.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type RentAdComplaint struct {
+	ID          int       `json:"id"`
+	RentAdID    int       `json:"rent_ad_id"`
+	UserID      int       `json:"user_id"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/models/rent_complaint.go
+++ b/internal/models/rent_complaint.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type RentComplaint struct {
+	ID          int       `json:"id"`
+	RentID      int       `json:"rent_id"`
+	UserID      int       `json:"user_id"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/models/work_ad_complaint.go
+++ b/internal/models/work_ad_complaint.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type WorkAdComplaint struct {
+	ID          int       `json:"id"`
+	WorkAdID    int       `json:"work_ad_id"`
+	UserID      int       `json:"user_id"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/models/work_complaint.go
+++ b/internal/models/work_complaint.go
@@ -1,0 +1,11 @@
+package models
+
+import "time"
+
+type WorkComplaint struct {
+	ID          int       `json:"id"`
+	WorkID      int       `json:"work_id"`
+	UserID      int       `json:"user_id"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/repositories/ad_complaint_repository.go
+++ b/internal/repositories/ad_complaint_repository.go
@@ -1,0 +1,62 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+type AdComplaintRepository struct {
+	DB *sql.DB
+}
+
+func (r *AdComplaintRepository) CreateAdComplaint(ctx context.Context, c models.AdComplaint) error {
+	query := `INSERT INTO ad_complaints (ad_id, user_id, description) VALUES (?, ?, ?)`
+	_, err := r.DB.ExecContext(ctx, query, c.AdID, c.UserID, c.Description)
+	return err
+}
+
+func (r *AdComplaintRepository) GetComplaintsByAdID(ctx context.Context, adID int) ([]models.AdComplaint, error) {
+	query := `SELECT id, ad_id, user_id, description, created_at FROM ad_complaints WHERE ad_id = ?`
+	rows, err := r.DB.QueryContext(ctx, query, adID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.AdComplaint
+	for rows.Next() {
+		var c models.AdComplaint
+		if err := rows.Scan(&c.ID, &c.AdID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}
+
+func (r *AdComplaintRepository) DeleteAdComplaintByID(ctx context.Context, id int) error {
+	query := `DELETE FROM ad_complaints WHERE id = ?`
+	_, err := r.DB.ExecContext(ctx, query, id)
+	return err
+}
+
+func (r *AdComplaintRepository) GetAllAdComplaints(ctx context.Context) ([]models.AdComplaint, error) {
+	query := `SELECT id, ad_id, user_id, description, created_at FROM ad_complaints ORDER BY created_at DESC`
+	rows, err := r.DB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.AdComplaint
+	for rows.Next() {
+		var c models.AdComplaint
+		if err := rows.Scan(&c.ID, &c.AdID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}

--- a/internal/repositories/rent_ad_complaint_repository.go
+++ b/internal/repositories/rent_ad_complaint_repository.go
@@ -1,0 +1,62 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+type RentAdComplaintRepository struct {
+	DB *sql.DB
+}
+
+func (r *RentAdComplaintRepository) CreateRentAdComplaint(ctx context.Context, c models.RentAdComplaint) error {
+	query := `INSERT INTO rent_ad_complaints (rent_ad_id, user_id, description) VALUES (?, ?, ?)`
+	_, err := r.DB.ExecContext(ctx, query, c.RentAdID, c.UserID, c.Description)
+	return err
+}
+
+func (r *RentAdComplaintRepository) GetComplaintsByRentAdID(ctx context.Context, rentAdID int) ([]models.RentAdComplaint, error) {
+	query := `SELECT id, rent_ad_id, user_id, description, created_at FROM rent_ad_complaints WHERE rent_ad_id = ?`
+	rows, err := r.DB.QueryContext(ctx, query, rentAdID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.RentAdComplaint
+	for rows.Next() {
+		var c models.RentAdComplaint
+		if err := rows.Scan(&c.ID, &c.RentAdID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}
+
+func (r *RentAdComplaintRepository) DeleteRentAdComplaintByID(ctx context.Context, id int) error {
+	query := `DELETE FROM rent_ad_complaints WHERE id = ?`
+	_, err := r.DB.ExecContext(ctx, query, id)
+	return err
+}
+
+func (r *RentAdComplaintRepository) GetAllRentAdComplaints(ctx context.Context) ([]models.RentAdComplaint, error) {
+	query := `SELECT id, rent_ad_id, user_id, description, created_at FROM rent_ad_complaints ORDER BY created_at DESC`
+	rows, err := r.DB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.RentAdComplaint
+	for rows.Next() {
+		var c models.RentAdComplaint
+		if err := rows.Scan(&c.ID, &c.RentAdID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}

--- a/internal/repositories/rent_complaint_repository.go
+++ b/internal/repositories/rent_complaint_repository.go
@@ -1,0 +1,62 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+type RentComplaintRepository struct {
+	DB *sql.DB
+}
+
+func (r *RentComplaintRepository) CreateRentComplaint(ctx context.Context, c models.RentComplaint) error {
+	query := `INSERT INTO rent_complaints (rent_id, user_id, description) VALUES (?, ?, ?)`
+	_, err := r.DB.ExecContext(ctx, query, c.RentID, c.UserID, c.Description)
+	return err
+}
+
+func (r *RentComplaintRepository) GetComplaintsByRentID(ctx context.Context, rentID int) ([]models.RentComplaint, error) {
+	query := `SELECT id, rent_id, user_id, description, created_at FROM rent_complaints WHERE rent_id = ?`
+	rows, err := r.DB.QueryContext(ctx, query, rentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.RentComplaint
+	for rows.Next() {
+		var c models.RentComplaint
+		if err := rows.Scan(&c.ID, &c.RentID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}
+
+func (r *RentComplaintRepository) DeleteRentComplaintByID(ctx context.Context, id int) error {
+	query := `DELETE FROM rent_complaints WHERE id = ?`
+	_, err := r.DB.ExecContext(ctx, query, id)
+	return err
+}
+
+func (r *RentComplaintRepository) GetAllRentComplaints(ctx context.Context) ([]models.RentComplaint, error) {
+	query := `SELECT id, rent_id, user_id, description, created_at FROM rent_complaints ORDER BY created_at DESC`
+	rows, err := r.DB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.RentComplaint
+	for rows.Next() {
+		var c models.RentComplaint
+		if err := rows.Scan(&c.ID, &c.RentID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}

--- a/internal/repositories/work_ad_complaint_repository.go
+++ b/internal/repositories/work_ad_complaint_repository.go
@@ -1,0 +1,62 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+type WorkAdComplaintRepository struct {
+	DB *sql.DB
+}
+
+func (r *WorkAdComplaintRepository) CreateWorkAdComplaint(ctx context.Context, c models.WorkAdComplaint) error {
+	query := `INSERT INTO work_ad_complaints (work_ad_id, user_id, description) VALUES (?, ?, ?)`
+	_, err := r.DB.ExecContext(ctx, query, c.WorkAdID, c.UserID, c.Description)
+	return err
+}
+
+func (r *WorkAdComplaintRepository) GetComplaintsByWorkAdID(ctx context.Context, workAdID int) ([]models.WorkAdComplaint, error) {
+	query := `SELECT id, work_ad_id, user_id, description, created_at FROM work_ad_complaints WHERE work_ad_id = ?`
+	rows, err := r.DB.QueryContext(ctx, query, workAdID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.WorkAdComplaint
+	for rows.Next() {
+		var c models.WorkAdComplaint
+		if err := rows.Scan(&c.ID, &c.WorkAdID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}
+
+func (r *WorkAdComplaintRepository) DeleteWorkAdComplaintByID(ctx context.Context, id int) error {
+	query := `DELETE FROM work_ad_complaints WHERE id = ?`
+	_, err := r.DB.ExecContext(ctx, query, id)
+	return err
+}
+
+func (r *WorkAdComplaintRepository) GetAllWorkAdComplaints(ctx context.Context) ([]models.WorkAdComplaint, error) {
+	query := `SELECT id, work_ad_id, user_id, description, created_at FROM work_ad_complaints ORDER BY created_at DESC`
+	rows, err := r.DB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.WorkAdComplaint
+	for rows.Next() {
+		var c models.WorkAdComplaint
+		if err := rows.Scan(&c.ID, &c.WorkAdID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}

--- a/internal/repositories/work_complaint_repository.go
+++ b/internal/repositories/work_complaint_repository.go
@@ -1,0 +1,62 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+
+	"naimuBack/internal/models"
+)
+
+type WorkComplaintRepository struct {
+	DB *sql.DB
+}
+
+func (r *WorkComplaintRepository) CreateWorkComplaint(ctx context.Context, c models.WorkComplaint) error {
+	query := `INSERT INTO work_complaints (work_id, user_id, description) VALUES (?, ?, ?)`
+	_, err := r.DB.ExecContext(ctx, query, c.WorkID, c.UserID, c.Description)
+	return err
+}
+
+func (r *WorkComplaintRepository) GetComplaintsByWorkID(ctx context.Context, workID int) ([]models.WorkComplaint, error) {
+	query := `SELECT id, work_id, user_id, description, created_at FROM work_complaints WHERE work_id = ?`
+	rows, err := r.DB.QueryContext(ctx, query, workID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.WorkComplaint
+	for rows.Next() {
+		var c models.WorkComplaint
+		if err := rows.Scan(&c.ID, &c.WorkID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}
+
+func (r *WorkComplaintRepository) DeleteWorkComplaintByID(ctx context.Context, id int) error {
+	query := `DELETE FROM work_complaints WHERE id = ?`
+	_, err := r.DB.ExecContext(ctx, query, id)
+	return err
+}
+
+func (r *WorkComplaintRepository) GetAllWorkComplaints(ctx context.Context) ([]models.WorkComplaint, error) {
+	query := `SELECT id, work_id, user_id, description, created_at FROM work_complaints ORDER BY created_at DESC`
+	rows, err := r.DB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var complaints []models.WorkComplaint
+	for rows.Next() {
+		var c models.WorkComplaint
+		if err := rows.Scan(&c.ID, &c.WorkID, &c.UserID, &c.Description, &c.CreatedAt); err != nil {
+			return nil, err
+		}
+		complaints = append(complaints, c)
+	}
+	return complaints, nil
+}

--- a/internal/services/ad_complaint_service.go
+++ b/internal/services/ad_complaint_service.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+type AdComplaintService struct {
+	ComplaintRepo *repositories.AdComplaintRepository
+}
+
+func (s *AdComplaintService) CreateAdComplaint(ctx context.Context, c models.AdComplaint) error {
+	return s.ComplaintRepo.CreateAdComplaint(ctx, c)
+}
+
+func (s *AdComplaintService) GetComplaintsByAdID(ctx context.Context, adID int) ([]models.AdComplaint, error) {
+	return s.ComplaintRepo.GetComplaintsByAdID(ctx, adID)
+}
+
+func (s *AdComplaintService) DeleteAdComplaintByID(ctx context.Context, id int) error {
+	return s.ComplaintRepo.DeleteAdComplaintByID(ctx, id)
+}
+
+func (s *AdComplaintService) GetAllAdComplaints(ctx context.Context) ([]models.AdComplaint, error) {
+	return s.ComplaintRepo.GetAllAdComplaints(ctx)
+}

--- a/internal/services/rent_ad_complaint_service.go
+++ b/internal/services/rent_ad_complaint_service.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+type RentAdComplaintService struct {
+	ComplaintRepo *repositories.RentAdComplaintRepository
+}
+
+func (s *RentAdComplaintService) CreateRentAdComplaint(ctx context.Context, c models.RentAdComplaint) error {
+	return s.ComplaintRepo.CreateRentAdComplaint(ctx, c)
+}
+
+func (s *RentAdComplaintService) GetComplaintsByRentAdID(ctx context.Context, rentAdID int) ([]models.RentAdComplaint, error) {
+	return s.ComplaintRepo.GetComplaintsByRentAdID(ctx, rentAdID)
+}
+
+func (s *RentAdComplaintService) DeleteRentAdComplaintByID(ctx context.Context, id int) error {
+	return s.ComplaintRepo.DeleteRentAdComplaintByID(ctx, id)
+}
+
+func (s *RentAdComplaintService) GetAllRentAdComplaints(ctx context.Context) ([]models.RentAdComplaint, error) {
+	return s.ComplaintRepo.GetAllRentAdComplaints(ctx)
+}

--- a/internal/services/rent_complaint_service.go
+++ b/internal/services/rent_complaint_service.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+type RentComplaintService struct {
+	ComplaintRepo *repositories.RentComplaintRepository
+}
+
+func (s *RentComplaintService) CreateRentComplaint(ctx context.Context, c models.RentComplaint) error {
+	return s.ComplaintRepo.CreateRentComplaint(ctx, c)
+}
+
+func (s *RentComplaintService) GetComplaintsByRentID(ctx context.Context, rentID int) ([]models.RentComplaint, error) {
+	return s.ComplaintRepo.GetComplaintsByRentID(ctx, rentID)
+}
+
+func (s *RentComplaintService) DeleteRentComplaintByID(ctx context.Context, id int) error {
+	return s.ComplaintRepo.DeleteRentComplaintByID(ctx, id)
+}
+
+func (s *RentComplaintService) GetAllRentComplaints(ctx context.Context) ([]models.RentComplaint, error) {
+	return s.ComplaintRepo.GetAllRentComplaints(ctx)
+}

--- a/internal/services/work_ad_complaint_service.go
+++ b/internal/services/work_ad_complaint_service.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+type WorkAdComplaintService struct {
+	ComplaintRepo *repositories.WorkAdComplaintRepository
+}
+
+func (s *WorkAdComplaintService) CreateWorkAdComplaint(ctx context.Context, c models.WorkAdComplaint) error {
+	return s.ComplaintRepo.CreateWorkAdComplaint(ctx, c)
+}
+
+func (s *WorkAdComplaintService) GetComplaintsByWorkAdID(ctx context.Context, workAdID int) ([]models.WorkAdComplaint, error) {
+	return s.ComplaintRepo.GetComplaintsByWorkAdID(ctx, workAdID)
+}
+
+func (s *WorkAdComplaintService) DeleteWorkAdComplaintByID(ctx context.Context, id int) error {
+	return s.ComplaintRepo.DeleteWorkAdComplaintByID(ctx, id)
+}
+
+func (s *WorkAdComplaintService) GetAllWorkAdComplaints(ctx context.Context) ([]models.WorkAdComplaint, error) {
+	return s.ComplaintRepo.GetAllWorkAdComplaints(ctx)
+}

--- a/internal/services/work_complaint_service.go
+++ b/internal/services/work_complaint_service.go
@@ -1,0 +1,28 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+type WorkComplaintService struct {
+	ComplaintRepo *repositories.WorkComplaintRepository
+}
+
+func (s *WorkComplaintService) CreateWorkComplaint(ctx context.Context, c models.WorkComplaint) error {
+	return s.ComplaintRepo.CreateWorkComplaint(ctx, c)
+}
+
+func (s *WorkComplaintService) GetComplaintsByWorkID(ctx context.Context, workID int) ([]models.WorkComplaint, error) {
+	return s.ComplaintRepo.GetComplaintsByWorkID(ctx, workID)
+}
+
+func (s *WorkComplaintService) DeleteWorkComplaintByID(ctx context.Context, id int) error {
+	return s.ComplaintRepo.DeleteWorkComplaintByID(ctx, id)
+}
+
+func (s *WorkComplaintService) GetAllWorkComplaints(ctx context.Context) ([]models.WorkComplaint, error) {
+	return s.ComplaintRepo.GetAllWorkComplaints(ctx)
+}


### PR DESCRIPTION
## Summary
- add complaint models and repositories for ad, work, work ad, rent and rent ad
- wire new complaint services and handlers with routes
- create database migrations for new complaint tables

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a316db3b9c83249cd4c33ae5318e56