### PR TITLE
Return 403 for missing subscription

### DIFF
--- a/internal/handlers/rent_handler.go
+++ b/internal/handlers/rent_handler.go
@@ -346,7 +346,7 @@ func (h *RentHandler) CreateRent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSubscription) {
 
-			http.Error(w, err.Error(), http.StatusOK)
+			http.Error(w, err.Error(), http.StatusForbidden)
 
 			return
 		}
@@ -447,7 +447,7 @@ func (h *RentHandler) UpdateRent(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSubscription) {
 
-			http.Error(w, err.Error(), http.StatusOK)
+			http.Error(w, err.Error(), http.StatusForbidden)
 
 			return
 		}

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -342,7 +342,7 @@ func (h *ServiceHandler) CreateService(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSubscription) {
 
-			http.Error(w, err.Error(), http.StatusOK)
+			http.Error(w, err.Error(), http.StatusForbidden)
 
 			return
 		}
@@ -439,7 +439,7 @@ func (h *ServiceHandler) UpdateService(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSubscription) {
 
-			http.Error(w, err.Error(), http.StatusOK)
+			http.Error(w, err.Error(), http.StatusForbidden)
 
 			return
 		}

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -349,8 +349,8 @@ func (h *WorkHandler) CreateWork(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSubscription) {
 
-			http.Error(w, err.Error(), http.StatusOK)
-
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
 		}
 		log.Printf("Failed to create service: %v", err)
 		http.Error(w, "Failed to create service", http.StatusInternalServerError)
@@ -452,8 +452,7 @@ func (h *WorkHandler) UpdateWork(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, services.ErrNoActiveSubscription) {
 
-			http.Error(w, err.Error(), http.StatusOK)
-
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 		log.Printf("Failed to update service: %v", err)


### PR DESCRIPTION
## Summary
- send `403 Forbidden` when no subscription is active

## Testing
- `go test ./...` *(fails: command produced no output and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c9cb81548324be3763ba2ff89099