### PR TITLE
Expose is_responded flag on detail endpoints

### DIFF
--- a/internal/handlers/ad_handler.go
+++ b/internal/handlers/ad_handler.go
@@ -36,7 +36,16 @@ func (h *AdHandler) GetAdByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ad, err := h.Service.GetAdByID(r.Context(), id)
+	userID := 0
+	if userIDStr := r.URL.Query().Get("user_id"); userIDStr != "" {
+		userID, err = strconv.Atoi(userIDStr)
+		if err != nil {
+			http.Error(w, "Invalid user ID", http.StatusBadRequest)
+			return
+		}
+	}
+
+	ad, err := h.Service.GetAdByID(r.Context(), id, userID)
 	if err != nil {
 		http.Error(w, "Service not found", http.StatusNotFound)
 		return

--- a/internal/handlers/rent_ad_handler.go
+++ b/internal/handlers/rent_ad_handler.go
@@ -36,7 +36,16 @@ func (h *RentAdHandler) GetRentAdByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rent, err := h.Service.GetRentAdByID(r.Context(), id)
+	userID := 0
+	if userIDStr := r.URL.Query().Get("user_id"); userIDStr != "" {
+		userID, err = strconv.Atoi(userIDStr)
+		if err != nil {
+			http.Error(w, "Invalid user ID", http.StatusBadRequest)
+			return
+		}
+	}
+
+	rent, err := h.Service.GetRentAdByID(r.Context(), id, userID)
 	if err != nil {
 		http.Error(w, "Service not found", http.StatusNotFound)
 		return

--- a/internal/handlers/rent_handler.go
+++ b/internal/handlers/rent_handler.go
@@ -36,7 +36,16 @@ func (h *RentHandler) GetRentByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rent, err := h.Service.GetRentByID(r.Context(), id)
+	userID := 0
+	if userIDStr := r.URL.Query().Get("user_id"); userIDStr != "" {
+		userID, err = strconv.Atoi(userIDStr)
+		if err != nil {
+			http.Error(w, "Invalid user ID", http.StatusBadRequest)
+			return
+		}
+	}
+
+	rent, err := h.Service.GetRentByID(r.Context(), id, userID)
 	if err != nil {
 		http.Error(w, "Service not found", http.StatusNotFound)
 		return

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -36,7 +36,16 @@ func (h *ServiceHandler) GetServiceByID(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	service, err := h.Service.GetServiceByID(r.Context(), id)
+	userID := 0
+	if userIDStr := r.URL.Query().Get("user_id"); userIDStr != "" {
+		userID, err = strconv.Atoi(userIDStr)
+		if err != nil {
+			http.Error(w, "Invalid user ID", http.StatusBadRequest)
+			return
+		}
+	}
+
+	service, err := h.Service.GetServiceByID(r.Context(), id, userID)
 	if err != nil {
 		http.Error(w, "Service not found", http.StatusNotFound)
 		return

--- a/internal/handlers/work_ad_handler.go
+++ b/internal/handlers/work_ad_handler.go
@@ -36,7 +36,16 @@ func (h *WorkAdHandler) GetWorkAdByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	work, err := h.Service.GetWorkAdByID(r.Context(), id)
+	userID := 0
+	if userIDStr := r.URL.Query().Get("user_id"); userIDStr != "" {
+		userID, err = strconv.Atoi(userIDStr)
+		if err != nil {
+			http.Error(w, "Invalid user ID", http.StatusBadRequest)
+			return
+		}
+	}
+
+	work, err := h.Service.GetWorkAdByID(r.Context(), id, userID)
 	if err != nil {
 		http.Error(w, "Service not found", http.StatusNotFound)
 		return

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -36,7 +36,16 @@ func (h *WorkHandler) GetWorkByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	work, err := h.Service.GetWorkByID(r.Context(), id)
+	userID := 0
+	if userIDStr := r.URL.Query().Get("user_id"); userIDStr != "" {
+		userID, err = strconv.Atoi(userIDStr)
+		if err != nil {
+			http.Error(w, "Invalid user ID", http.StatusBadRequest)
+			return
+		}
+	}
+
+	work, err := h.Service.GetWorkByID(r.Context(), id, userID)
 	if err != nil {
 		http.Error(w, "Service not found", http.StatusNotFound)
 		return

--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -26,6 +26,7 @@ type Ad struct {
 	AvgRating       float64    `json:"avg_rating"`
 	Top             string     `json:"top, omitempty"`
 	Liked           bool       `json:"liked, omitempty"`
+	Responded       bool       `json:"is_responded"`
 	Status          string     `json:"status, omitempty"`
 	CategoryName    string     `json:"category_name"`
 	SubcategoryName string     `json:"subcategory_name"`

--- a/internal/models/rent.go
+++ b/internal/models/rent.go
@@ -26,6 +26,7 @@ type Rent struct {
 	AvgRating       float64     `json:"avg_rating"`
 	Top             string      `json:"top, omitempty"`
 	Liked           bool        `json:"liked, omitempty"`
+	Responded       bool        `json:"is_responded"`
 	Status          string      `json:"status, omitempty"`
 	CategoryName    string      `json:"category_name"`
 	SubcategoryName string      `json:"subcategory_name"`

--- a/internal/models/rent_ad.go
+++ b/internal/models/rent_ad.go
@@ -26,6 +26,7 @@ type RentAd struct {
 	AvgRating       float64       `json:"avg_rating"`
 	Top             string        `json:"top, omitempty"`
 	Liked           bool          `json:"liked, omitempty"`
+	Responded       bool          `json:"is_responded"`
 	Status          string        `json:"status, omitempty"`
 	CategoryName    string        `json:"category_name"`
 	SubcategoryName string        `json:"subcategory_name"`

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -26,6 +26,7 @@ type Service struct {
 	AvgRating       float64    `json:"avg_rating"`
 	Top             string     `json:"top, omitempty"`
 	Liked           bool       `json:"liked, omitempty"`
+	Responded       bool       `json:"is_responded"`
 	Status          string     `json:"status, omitempty"`
 	CategoryName    string     `json:"category_name"`
 	SubcategoryName string     `json:"subcategory_name"`

--- a/internal/models/work.go
+++ b/internal/models/work.go
@@ -26,6 +26,7 @@ type Work struct {
 	AvgRating       float64     `json:"avg_rating"`
 	Top             string      `json:"top, omitempty"`
 	Liked           bool        `json:"liked, omitempty"`
+	Responded       bool        `json:"is_responded"`
 	Status          string      `json:"status, omitempty"`
 	CategoryName    string      `json:"category_name"`
 	SubcategoryName string      `json:"subcategory_name"`

--- a/internal/models/work_ad.go
+++ b/internal/models/work_ad.go
@@ -26,6 +26,7 @@ type WorkAd struct {
 	AvgRating       float64       `json:"avg_rating"`
 	Top             string        `json:"top, omitempty"`
 	Liked           bool          `json:"liked, omitempty"`
+	Responded       bool          `json:"is_responded"`
 	Status          string        `json:"status, omitempty"`
 	CategoryName    string        `json:"category_name"`
 	SubcategoryName string        `json:"subcategory_name"`

--- a/internal/services/ad_responses_service.go
+++ b/internal/services/ad_responses_service.go
@@ -21,7 +21,7 @@ func (s *AdResponseService) CreateAdResponse(ctx context.Context, resp models.Ad
 		return resp, err
 	}
 
-	ad, err := s.AdRepo.GetAdByID(ctx, resp.AdID)
+	ad, err := s.AdRepo.GetAdByID(ctx, resp.AdID, 0)
 	if err != nil {
 		return resp, err
 	}
@@ -51,8 +51,7 @@ func (s *AdResponseService) CreateAdResponse(ctx context.Context, resp models.Ad
 		ReceiverID: ad.UserID,
 		Text:       text,
 
-		ChatID:     chatID,
-
+		ChatID: chatID,
 	}); err != nil {
 		return resp, err
 	}

--- a/internal/services/ad_service.go
+++ b/internal/services/ad_service.go
@@ -14,8 +14,8 @@ func (s *AdService) CreateAd(ctx context.Context, ad models.Ad) (models.Ad, erro
 	return s.AdRepo.CreateAd(ctx, ad)
 }
 
-func (s *AdService) GetAdByID(ctx context.Context, id int) (models.Ad, error) {
-	return s.AdRepo.GetAdByID(ctx, id)
+func (s *AdService) GetAdByID(ctx context.Context, id int, userID int) (models.Ad, error) {
+	return s.AdRepo.GetAdByID(ctx, id, userID)
 }
 
 func (s *AdService) UpdateAd(ctx context.Context, service models.Ad) (models.Ad, error) {

--- a/internal/services/rent_ad_responses_service.go
+++ b/internal/services/rent_ad_responses_service.go
@@ -21,7 +21,7 @@ func (s *RentAdResponseService) CreateRentAdResponse(ctx context.Context, resp m
 		return resp, err
 	}
 
-	rent, err := s.RentAdRepo.GetRentAdByID(ctx, resp.RentAdID)
+	rent, err := s.RentAdRepo.GetRentAdByID(ctx, resp.RentAdID, 0)
 	if err != nil {
 		return resp, err
 	}
@@ -51,8 +51,7 @@ func (s *RentAdResponseService) CreateRentAdResponse(ctx context.Context, resp m
 		ReceiverID: rent.UserID,
 		Text:       text,
 
-		ChatID:     chatID,
-
+		ChatID: chatID,
 	}); err != nil {
 		return resp, err
 	}

--- a/internal/services/rent_ad_service.go
+++ b/internal/services/rent_ad_service.go
@@ -14,8 +14,8 @@ func (s *RentAdService) CreateRentAd(ctx context.Context, work models.RentAd) (m
 	return s.RentAdRepo.CreateRentAd(ctx, work)
 }
 
-func (s *RentAdService) GetRentAdByID(ctx context.Context, id int) (models.RentAd, error) {
-	return s.RentAdRepo.GetRentAdByID(ctx, id)
+func (s *RentAdService) GetRentAdByID(ctx context.Context, id int, userID int) (models.RentAd, error) {
+	return s.RentAdRepo.GetRentAdByID(ctx, id, userID)
 }
 
 func (s *RentAdService) UpdateRentAd(ctx context.Context, work models.RentAd) (models.RentAd, error) {

--- a/internal/services/rent_responses_service.go
+++ b/internal/services/rent_responses_service.go
@@ -21,7 +21,7 @@ func (s *RentResponseService) CreateRentResponse(ctx context.Context, resp model
 		return resp, err
 	}
 
-	rent, err := s.RentRepo.GetRentByID(ctx, resp.RentID)
+	rent, err := s.RentRepo.GetRentByID(ctx, resp.RentID, 0)
 	if err != nil {
 		return resp, err
 	}
@@ -51,8 +51,7 @@ func (s *RentResponseService) CreateRentResponse(ctx context.Context, resp model
 		ReceiverID: rent.UserID,
 		Text:       text,
 
-		ChatID:     chatID,
-
+		ChatID: chatID,
 	}); err != nil {
 		return resp, err
 	}

--- a/internal/services/rent_service.go
+++ b/internal/services/rent_service.go
@@ -22,13 +22,13 @@ func (s *RentService) CreateRent(ctx context.Context, work models.Rent) (models.
 	return s.RentRepo.CreateRent(ctx, work)
 }
 
-func (s *RentService) GetRentByID(ctx context.Context, id int) (models.Rent, error) {
-	return s.RentRepo.GetRentByID(ctx, id)
+func (s *RentService) GetRentByID(ctx context.Context, id int, userID int) (models.Rent, error) {
+	return s.RentRepo.GetRentByID(ctx, id, userID)
 }
 
 func (s *RentService) UpdateRent(ctx context.Context, work models.Rent) (models.Rent, error) {
 	if work.Status == "active" {
-		existing, err := s.RentRepo.GetRentByID(ctx, work.ID)
+		existing, err := s.RentRepo.GetRentByID(ctx, work.ID, 0)
 		if err != nil {
 			return models.Rent{}, err
 		}

--- a/internal/services/service_response_service.go
+++ b/internal/services/service_response_service.go
@@ -22,7 +22,7 @@ func (s *ServiceResponseService) CreateServiceResponse(ctx context.Context, resp
 		return resp, err
 	}
 
-	service, err := s.ServiceRepo.GetServiceByID(ctx, resp.ServiceID)
+	service, err := s.ServiceRepo.GetServiceByID(ctx, resp.ServiceID, 0)
 	if err != nil {
 		return resp, err
 	}
@@ -51,8 +51,7 @@ func (s *ServiceResponseService) CreateServiceResponse(ctx context.Context, resp
 		ReceiverID: service.UserID,
 		Text:       text,
 
-		ChatID:     chatID,
-
+		ChatID: chatID,
 	}); err != nil {
 		return resp, err
 	}

--- a/internal/services/service_service.go
+++ b/internal/services/service_service.go
@@ -22,13 +22,13 @@ func (s *ServiceService) CreateService(ctx context.Context, service models.Servi
 	return s.ServiceRepo.CreateService(ctx, service)
 }
 
-func (s *ServiceService) GetServiceByID(ctx context.Context, id int) (models.Service, error) {
-	return s.ServiceRepo.GetServiceByID(ctx, id)
+func (s *ServiceService) GetServiceByID(ctx context.Context, id int, userID int) (models.Service, error) {
+	return s.ServiceRepo.GetServiceByID(ctx, id, userID)
 }
 
 func (s *ServiceService) UpdateService(ctx context.Context, service models.Service) (models.Service, error) {
 	if service.Status == "active" {
-		existing, err := s.ServiceRepo.GetServiceByID(ctx, service.ID)
+		existing, err := s.ServiceRepo.GetServiceByID(ctx, service.ID, 0)
 		if err != nil {
 			return models.Service{}, err
 		}

--- a/internal/services/work_ad_responses_service.go
+++ b/internal/services/work_ad_responses_service.go
@@ -21,7 +21,7 @@ func (s *WorkAdResponseService) CreateWorkAdResponse(ctx context.Context, resp m
 		return resp, err
 	}
 
-	work, err := s.WorkAdRepo.GetWorkAdByID(ctx, resp.WorkAdID)
+	work, err := s.WorkAdRepo.GetWorkAdByID(ctx, resp.WorkAdID, 0)
 	if err != nil {
 		return resp, err
 	}

--- a/internal/services/work_ad_service.go
+++ b/internal/services/work_ad_service.go
@@ -14,8 +14,8 @@ func (s *WorkAdService) CreateWorkAd(ctx context.Context, work models.WorkAd) (m
 	return s.WorkAdRepo.CreateWorkAd(ctx, work)
 }
 
-func (s *WorkAdService) GetWorkAdByID(ctx context.Context, id int) (models.WorkAd, error) {
-	return s.WorkAdRepo.GetWorkAdByID(ctx, id)
+func (s *WorkAdService) GetWorkAdByID(ctx context.Context, id int, userID int) (models.WorkAd, error) {
+	return s.WorkAdRepo.GetWorkAdByID(ctx, id, userID)
 }
 
 func (s *WorkAdService) UpdateWorkAd(ctx context.Context, work models.WorkAd) (models.WorkAd, error) {

--- a/internal/services/work_response_service.go
+++ b/internal/services/work_response_service.go
@@ -21,7 +21,7 @@ func (s *WorkResponseService) CreateWorkResponse(ctx context.Context, resp model
 		return resp, err
 	}
 
-	work, err := s.WorkRepo.GetWorkByID(ctx, resp.WorkID)
+	work, err := s.WorkRepo.GetWorkByID(ctx, resp.WorkID, 0)
 	if err != nil {
 		return resp, err
 	}
@@ -51,8 +51,7 @@ func (s *WorkResponseService) CreateWorkResponse(ctx context.Context, resp model
 		ReceiverID: work.UserID,
 		Text:       text,
 
-		ChatID:     chatID,
-
+		ChatID: chatID,
 	}); err != nil {
 		return resp, err
 	}

--- a/internal/services/work_service.go
+++ b/internal/services/work_service.go
@@ -22,13 +22,13 @@ func (s *WorkService) CreateWork(ctx context.Context, work models.Work) (models.
 	return s.WorkRepo.CreateWork(ctx, work)
 }
 
-func (s *WorkService) GetWorkByID(ctx context.Context, id int) (models.Work, error) {
-	return s.WorkRepo.GetWorkByID(ctx, id)
+func (s *WorkService) GetWorkByID(ctx context.Context, id int, userID int) (models.Work, error) {
+	return s.WorkRepo.GetWorkByID(ctx, id, userID)
 }
 
 func (s *WorkService) UpdateWork(ctx context.Context, work models.Work) (models.Work, error) {
 	if work.Status == "active" {
-		existing, err := s.WorkRepo.GetWorkByID(ctx, work.ID)
+		existing, err := s.WorkRepo.GetWorkByID(ctx, work.ID, 0)
 		if err != nil {
 			return models.Work{}, err
 		}


### PR DESCRIPTION
## Summary
- include `is_responded` in service/ad/work/rent detail models
- compute response status in repositories and accept optional `user_id`
- allow handlers to pass through user ID when fetching by ID

## Testing
- `go test ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5790f18f883248050cdaca5e5edf2