### PR TITLE
Set order active on confirmation

### DIFF
--- a/docs/service_confirmation_postman.md
+++ b/docs/service_confirmation_postman.md
@@ -41,6 +41,6 @@ This document demonstrates how to create a service response and confirm a perfor
   "performer_id": 5
 }
 ```
-- **Expected Result:** HTTP 200 OK. The service status changes to `in progress`, all other responses are deleted, and the chat remains for further communication.
+- **Expected Result:** HTTP 200 OK. The service status changes to `active`, all other responses are deleted, and the chat remains for further communication.
 
 In Postman, ensure you include the user's JWT token in the Authorization header (`Bearer <token>`).

--- a/internal/repositories/ad_confirmation_repository.go
+++ b/internal/repositories/ad_confirmation_repository.go
@@ -43,7 +43,7 @@ func (r *AdConfirmationRepository) Confirm(ctx context.Context, adID, performerI
 	if err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `UPDATE ad SET status = 'in progress' WHERE id = ?`, adID)
+	_, err = tx.ExecContext(ctx, `UPDATE ad SET status = 'active' WHERE id = ?`, adID)
 	if err != nil {
 		return err
 	}

--- a/internal/repositories/rent_ad_confirmation_repository.go
+++ b/internal/repositories/rent_ad_confirmation_repository.go
@@ -43,7 +43,7 @@ func (r *RentAdConfirmationRepository) Confirm(ctx context.Context, rentAdID, pe
 	if err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `UPDATE rent_ad SET status = 'in progress' WHERE id = ?`, rentAdID)
+	_, err = tx.ExecContext(ctx, `UPDATE rent_ad SET status = 'active' WHERE id = ?`, rentAdID)
 	if err != nil {
 		return err
 	}

--- a/internal/repositories/rent_confirmation_repository.go
+++ b/internal/repositories/rent_confirmation_repository.go
@@ -43,7 +43,7 @@ func (r *RentConfirmationRepository) Confirm(ctx context.Context, rentID, perfor
 	if err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `UPDATE rent SET status = 'in progress' WHERE id = ?`, rentID)
+	_, err = tx.ExecContext(ctx, `UPDATE rent SET status = 'active' WHERE id = ?`, rentID)
 	if err != nil {
 		return err
 	}

--- a/internal/repositories/service_confirmation_repository.go
+++ b/internal/repositories/service_confirmation_repository.go
@@ -43,7 +43,7 @@ func (r *ServiceConfirmationRepository) Confirm(ctx context.Context, serviceID, 
 	if err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `UPDATE service SET status = 'in progress' WHERE id = ?`, serviceID)
+	_, err = tx.ExecContext(ctx, `UPDATE service SET status = 'active' WHERE id = ?`, serviceID)
 	if err != nil {
 		return err
 	}

--- a/internal/repositories/work_ad_confirmation_repository.go
+++ b/internal/repositories/work_ad_confirmation_repository.go
@@ -43,7 +43,7 @@ func (r *WorkAdConfirmationRepository) Confirm(ctx context.Context, workAdID, pe
 	if err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `UPDATE work_ad SET status = 'in progress' WHERE id = ?`, workAdID)
+	_, err = tx.ExecContext(ctx, `UPDATE work_ad SET status = 'active' WHERE id = ?`, workAdID)
 	if err != nil {
 		return err
 	}

--- a/internal/repositories/work_confirmation_repository.go
+++ b/internal/repositories/work_confirmation_repository.go
@@ -43,7 +43,7 @@ func (r *WorkConfirmationRepository) Confirm(ctx context.Context, workID, perfor
 	if err != nil {
 		return err
 	}
-	_, err = tx.ExecContext(ctx, `UPDATE work SET status = 'in progress' WHERE id = ?`, workID)
+	_, err = tx.ExecContext(ctx, `UPDATE work SET status = 'active' WHERE id = ?`, workID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- mark service, ad, rent, work, rent ad and work ad as `active` on confirmation
- update service confirmation documentation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a5aba704048324abe8d579cd8e7ab1