### PR TITLE
Decrement subscription responses on confirmations

### DIFF
--- a/internal/repositories/ad_confirmation_repository.go
+++ b/internal/repositories/ad_confirmation_repository.go
@@ -47,6 +47,10 @@ func (r *AdConfirmationRepository) Confirm(ctx context.Context, adID, performerI
 	if err != nil {
 		return err
 	}
+	_, err = tx.ExecContext(ctx, `UPDATE subscription_responses SET remaining = remaining - 1 WHERE user_id = ? AND remaining > 0`, performerID)
+	if err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 

--- a/internal/repositories/rent_ad_confirmation_repository.go
+++ b/internal/repositories/rent_ad_confirmation_repository.go
@@ -47,6 +47,10 @@ func (r *RentAdConfirmationRepository) Confirm(ctx context.Context, rentAdID, pe
 	if err != nil {
 		return err
 	}
+	_, err = tx.ExecContext(ctx, `UPDATE subscription_responses SET remaining = remaining - 1 WHERE user_id = ? AND remaining > 0`, performerID)
+	if err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 

--- a/internal/repositories/rent_confirmation_repository.go
+++ b/internal/repositories/rent_confirmation_repository.go
@@ -47,6 +47,10 @@ func (r *RentConfirmationRepository) Confirm(ctx context.Context, rentID, perfor
 	if err != nil {
 		return err
 	}
+	_, err = tx.ExecContext(ctx, `UPDATE subscription_responses SET remaining = remaining - 1 WHERE user_id = ? AND remaining > 0`, performerID)
+	if err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 

--- a/internal/repositories/service_confirmation_repository.go
+++ b/internal/repositories/service_confirmation_repository.go
@@ -47,6 +47,10 @@ func (r *ServiceConfirmationRepository) Confirm(ctx context.Context, serviceID, 
 	if err != nil {
 		return err
 	}
+	_, err = tx.ExecContext(ctx, `UPDATE subscription_responses SET remaining = remaining - 1 WHERE user_id = ? AND remaining > 0`, performerID)
+	if err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 

--- a/internal/repositories/work_ad_confirmation_repository.go
+++ b/internal/repositories/work_ad_confirmation_repository.go
@@ -47,6 +47,10 @@ func (r *WorkAdConfirmationRepository) Confirm(ctx context.Context, workAdID, pe
 	if err != nil {
 		return err
 	}
+	_, err = tx.ExecContext(ctx, `UPDATE subscription_responses SET remaining = remaining - 1 WHERE user_id = ? AND remaining > 0`, performerID)
+	if err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 

--- a/internal/repositories/work_confirmation_repository.go
+++ b/internal/repositories/work_confirmation_repository.go
@@ -47,6 +47,10 @@ func (r *WorkConfirmationRepository) Confirm(ctx context.Context, workID, perfor
 	if err != nil {
 		return err
 	}
+	_, err = tx.ExecContext(ctx, `UPDATE subscription_responses SET remaining = remaining - 1 WHERE user_id = ? AND remaining > 0`, performerID)
+	if err != nil {
+		return err
+	}
 	return tx.Commit()
 }
 


### PR DESCRIPTION
## Summary
- deduct one remaining response for a user whenever any service/work/ad confirmation is made

## Testing
- `go test ./...` *(no output, possibly no tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a661fe81bc832489d3f33975da3156