### PR TITLE
Add endpoints to archive services and related entities

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -54,11 +54,12 @@ func (app *application) routes() http.Handler {
 	mux.Get("/ads", standardMiddleware.ThenFunc(app.adHandler.GetAds))
 
 	// Service
-	mux.Post("/service", authMiddleware.ThenFunc(app.serviceHandler.CreateService))                                 //РАБОТАЕТ
-	mux.Get("/service/get", standardMiddleware.ThenFunc(app.serviceHandler.GetServices))                            //РАБОТАЕТ
-	mux.Get("/service/:id", standardMiddleware.ThenFunc(app.serviceHandler.GetServiceByID))                         //РАБОТАЕТ
-	mux.Put("/service/:id", authMiddleware.ThenFunc(app.serviceHandler.UpdateService))                              //РАБОТАЕТ
-	mux.Del("/service/:id", authMiddleware.ThenFunc(app.serviceHandler.DeleteService))                              //РАБОТАЕТ
+	mux.Post("/service", authMiddleware.ThenFunc(app.serviceHandler.CreateService))         //РАБОТАЕТ
+	mux.Get("/service/get", standardMiddleware.ThenFunc(app.serviceHandler.GetServices))    //РАБОТАЕТ
+	mux.Get("/service/:id", standardMiddleware.ThenFunc(app.serviceHandler.GetServiceByID)) //РАБОТАЕТ
+	mux.Put("/service/:id", authMiddleware.ThenFunc(app.serviceHandler.UpdateService))      //РАБОТАЕТ
+	mux.Del("/service/:id", authMiddleware.ThenFunc(app.serviceHandler.DeleteService))      //РАБОТАЕТ
+	mux.Post("/service/archive", authMiddleware.ThenFunc(app.serviceHandler.ArchiveService))
 	mux.Get("/service/sort/:type/user/:user_id", standardMiddleware.ThenFunc(app.serviceHandler.GetServicesSorted)) //user_id - id пользователя который авторизован
 	mux.Get("/service/user/:user_id", standardMiddleware.ThenFunc(app.serviceHandler.GetServiceByUserID))           //РАБОТАЕТ
 	mux.Post("/service/filtered", standardMiddleware.ThenFunc(app.serviceHandler.GetFilteredServicesPost))          //РАБОТАЕТ
@@ -202,6 +203,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/work/:id", standardMiddleware.ThenFunc(app.workHandler.GetWorkByID))
 	mux.Put("/work/:id", authMiddleware.ThenFunc(app.workHandler.UpdateWork))
 	mux.Del("/work/:id", authMiddleware.ThenFunc(app.workHandler.DeleteWork))
+	mux.Post("/work/archive", authMiddleware.ThenFunc(app.workHandler.ArchiveWork))
 	mux.Get("/work/user/:user_id", authMiddleware.ThenFunc(app.workHandler.GetWorksByUserID))
 	mux.Post("/work/filtered", standardMiddleware.ThenFunc(app.workHandler.GetFilteredWorksPost))
 	mux.Post("/work/status", authMiddleware.ThenFunc(app.workHandler.GetWorksByStatusAndUserID))
@@ -233,6 +235,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/rent/:id", standardMiddleware.ThenFunc(app.rentHandler.GetRentByID))
 	mux.Put("/rent/:id", authMiddleware.ThenFunc(app.rentHandler.UpdateRent))
 	mux.Del("/rent/:id", authMiddleware.ThenFunc(app.rentHandler.DeleteRent))
+	mux.Post("/rent/archive", authMiddleware.ThenFunc(app.rentHandler.ArchiveRent))
 	mux.Get("/rent/user/:user_id", authMiddleware.ThenFunc(app.rentHandler.GetRentsByUserID))
 	mux.Post("/rent/filtered", standardMiddleware.ThenFunc(app.rentHandler.GetFilteredRentsPost))
 	mux.Post("/rent/status", authMiddleware.ThenFunc(app.rentHandler.GetRentsByStatusAndUserID))
@@ -264,6 +267,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/ad/:id", standardMiddleware.ThenFunc(app.adHandler.GetAdByID))
 	mux.Put("/ad/:id", authMiddleware.ThenFunc(app.adHandler.UpdateAd))
 	mux.Del("/ad/:id", authMiddleware.ThenFunc(app.adHandler.DeleteAd))
+	mux.Post("/ad/archive", authMiddleware.ThenFunc(app.adHandler.ArchiveAd))
 	mux.Get("/ad/user/:user_id", authMiddleware.ThenFunc(app.adHandler.GetAdByUserID))
 	mux.Post("/ad/filtered", standardMiddleware.ThenFunc(app.adHandler.GetFilteredAdPost))
 	mux.Post("/ad/status", authMiddleware.ThenFunc(app.adHandler.GetAdByStatusAndUserID))
@@ -295,6 +299,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/work_ad/:id", standardMiddleware.ThenFunc(app.workAdHandler.GetWorkAdByID))
 	mux.Put("/work_ad/:id", authMiddleware.ThenFunc(app.workAdHandler.UpdateWorkAd))
 	mux.Del("/work_ad/:id", authMiddleware.ThenFunc(app.workAdHandler.DeleteWorkAd))
+	mux.Post("/work_ad/archive", authMiddleware.ThenFunc(app.workAdHandler.ArchiveWorkAd))
 	mux.Get("/work_ad/user/:user_id", authMiddleware.ThenFunc(app.workAdHandler.GetWorksAdByUserID))
 	mux.Post("/work_ad/filtered", standardMiddleware.ThenFunc(app.workAdHandler.GetFilteredWorksAdPost))
 	mux.Post("/work_ad/status", authMiddleware.ThenFunc(app.workAdHandler.GetWorksAdByStatusAndUserID))
@@ -326,6 +331,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/rent_ad/:id", standardMiddleware.ThenFunc(app.rentAdHandler.GetRentAdByID))
 	mux.Put("/rent_ad/:id", authMiddleware.ThenFunc(app.rentAdHandler.UpdateRentAd))
 	mux.Del("/rent_ad/:id", authMiddleware.ThenFunc(app.rentAdHandler.DeleteRentAd))
+	mux.Post("/rent_ad/archive", authMiddleware.ThenFunc(app.rentAdHandler.ArchiveRentAd))
 	mux.Get("/rent_ad/user/:user_id", authMiddleware.ThenFunc(app.rentAdHandler.GetRentsAdByUserID))
 	mux.Post("/rent_ad/filtered", standardMiddleware.ThenFunc(app.rentAdHandler.GetFilteredRentsAdPost))
 	mux.Post("/rent_ad/status", authMiddleware.ThenFunc(app.rentAdHandler.GetRentsAdByStatusAndUserID))

--- a/internal/handlers/ad_handler.go
+++ b/internal/handlers/ad_handler.go
@@ -87,6 +87,21 @@ func (h *AdHandler) DeleteAd(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *AdHandler) ArchiveAd(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		AdID int `json:"ad_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.ArchiveAd(r.Context(), req.AdID); err != nil {
+		http.Error(w, "Failed to archive ad", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 func (h *AdHandler) GetAd(w http.ResponseWriter, r *http.Request) {
 	// Чтение query-параметров
 	categories := parseIntArrayAd(r.URL.Query().Get("categories"))

--- a/internal/handlers/rent_ad_handler.go
+++ b/internal/handlers/rent_ad_handler.go
@@ -87,6 +87,21 @@ func (h *RentAdHandler) DeleteRentAd(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *RentAdHandler) ArchiveRentAd(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RentAdID int `json:"rent_ad_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.ArchiveRentAd(r.Context(), req.RentAdID); err != nil {
+		http.Error(w, "Failed to archive rent ad", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 func (h *RentAdHandler) GetRentsAd(w http.ResponseWriter, r *http.Request) {
 	// Чтение query-параметров
 	categories := parseIntArrayRentAd(r.URL.Query().Get("categories"))

--- a/internal/handlers/rent_handler.go
+++ b/internal/handlers/rent_handler.go
@@ -87,6 +87,21 @@ func (h *RentHandler) DeleteRent(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *RentHandler) ArchiveRent(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		RentID int `json:"rent_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.ArchiveRent(r.Context(), req.RentID); err != nil {
+		http.Error(w, "Failed to archive rent", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 func (h *RentHandler) GetRents(w http.ResponseWriter, r *http.Request) {
 	// Чтение query-параметров
 	categories := parseIntArrayRent(r.URL.Query().Get("categories"))

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -87,6 +87,21 @@ func (h *ServiceHandler) DeleteService(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *ServiceHandler) ArchiveService(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ServiceID int `json:"service_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.ArchiveService(r.Context(), req.ServiceID); err != nil {
+		http.Error(w, "Failed to archive service", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 func (h *ServiceHandler) GetServices(w http.ResponseWriter, r *http.Request) {
 	// Чтение query-параметров
 	categories := parseIntArray(r.URL.Query().Get("categories"))

--- a/internal/handlers/work_ad_handler.go
+++ b/internal/handlers/work_ad_handler.go
@@ -87,6 +87,21 @@ func (h *WorkAdHandler) DeleteWorkAd(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *WorkAdHandler) ArchiveWorkAd(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		WorkAdID int `json:"work_ad_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.ArchiveWorkAd(r.Context(), req.WorkAdID); err != nil {
+		http.Error(w, "Failed to archive work ad", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 func (h *WorkAdHandler) GetWorksAd(w http.ResponseWriter, r *http.Request) {
 	// Чтение query-параметров
 	categories := parseIntArrayWorkAd(r.URL.Query().Get("categories"))

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -87,6 +87,21 @@ func (h *WorkHandler) DeleteWork(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+func (h *WorkHandler) ArchiveWork(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		WorkID int `json:"work_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+	if err := h.Service.ArchiveWork(r.Context(), req.WorkID); err != nil {
+		http.Error(w, "Failed to archive work", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
 func (h *WorkHandler) GetWorks(w http.ResponseWriter, r *http.Request) {
 	// Чтение query-параметров
 	categories := parseIntArrayWork(r.URL.Query().Get("categories"))

--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -151,6 +151,22 @@ func (r *AdRepository) DeleteAd(ctx context.Context, id int) error {
 	}
 	return nil
 }
+
+func (r *AdRepository) UpdateStatus(ctx context.Context, id int, status string) error {
+	query := `UPDATE ad SET status = ?, updated_at = ? WHERE id = ?`
+	res, err := r.DB.ExecContext(ctx, query, status, time.Now(), id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrAdNotFound
+	}
+	return nil
+}
 func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Ad, float64, float64, error) {
 	var (
 		ads        []models.Ad

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -152,6 +152,22 @@ func (r *RentAdRepository) DeleteRentAd(ctx context.Context, id int) error {
 	}
 	return nil
 }
+
+func (r *RentAdRepository) UpdateStatus(ctx context.Context, id int, status string) error {
+	query := `UPDATE rent_ad SET status = ?, updated_at = ? WHERE id = ?`
+	res, err := r.DB.ExecContext(ctx, query, status, time.Now(), id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrRentAdNotFound
+	}
+	return nil
+}
 func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.RentAd, float64, float64, error) {
 	var (
 		rents      []models.RentAd

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -152,6 +152,22 @@ func (r *RentRepository) DeleteRent(ctx context.Context, id int) error {
 	}
 	return nil
 }
+
+func (r *RentRepository) UpdateStatus(ctx context.Context, id int, status string) error {
+	query := `UPDATE rent SET status = ?, updated_at = ? WHERE id = ?`
+	res, err := r.DB.ExecContext(ctx, query, status, time.Now(), id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrRentNotFound
+	}
+	return nil
+}
 func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Rent, float64, float64, error) {
 	var (
 		rents      []models.Rent

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -152,6 +152,22 @@ func (r *ServiceRepository) DeleteService(ctx context.Context, id int) error {
 	}
 	return nil
 }
+
+func (r *ServiceRepository) UpdateStatus(ctx context.Context, id int, status string) error {
+	query := `UPDATE service SET status = ?, updated_at = ? WHERE id = ?`
+	res, err := r.DB.ExecContext(ctx, query, status, time.Now(), id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrServiceNotFound
+	}
+	return nil
+}
 func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Service, float64, float64, error) {
 	var (
 		services   []models.Service

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -156,6 +156,22 @@ func (r *WorkAdRepository) DeleteWorkAd(ctx context.Context, id int) error {
 	}
 	return nil
 }
+
+func (r *WorkAdRepository) UpdateStatus(ctx context.Context, id int, status string) error {
+	query := `UPDATE work_ad SET status = ?, updated_at = ? WHERE id = ?`
+	res, err := r.DB.ExecContext(ctx, query, status, time.Now(), id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrWorkAdNotFound
+	}
+	return nil
+}
 func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.WorkAd, float64, float64, error) {
 	var (
 		works_ad   []models.WorkAd

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -159,6 +159,22 @@ func (r *WorkRepository) DeleteWork(ctx context.Context, id int) error {
 	}
 	return nil
 }
+
+func (r *WorkRepository) UpdateStatus(ctx context.Context, id int, status string) error {
+	query := `UPDATE work SET status = ?, updated_at = ? WHERE id = ?`
+	res, err := r.DB.ExecContext(ctx, query, status, time.Now(), id)
+	if err != nil {
+		return err
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if rows == 0 {
+		return ErrWorkNotFound
+	}
+	return nil
+}
 func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Work, float64, float64, error) {
 	var (
 		works      []models.Work

--- a/internal/services/ad_service.go
+++ b/internal/services/ad_service.go
@@ -26,6 +26,10 @@ func (s *AdService) DeleteAd(ctx context.Context, id int) error {
 	return s.AdRepo.DeleteAd(ctx, id)
 }
 
+func (s *AdService) ArchiveAd(ctx context.Context, id int) error {
+	return s.AdRepo.UpdateStatus(ctx, id, "archive")
+}
+
 func (s *AdService) GetFilteredAd(ctx context.Context, filter models.AdFilterRequest, userID int) (models.AdListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1

--- a/internal/services/rent_ad_service.go
+++ b/internal/services/rent_ad_service.go
@@ -26,6 +26,10 @@ func (s *RentAdService) DeleteRentAd(ctx context.Context, id int) error {
 	return s.RentAdRepo.DeleteRentAd(ctx, id)
 }
 
+func (s *RentAdService) ArchiveRentAd(ctx context.Context, id int) error {
+	return s.RentAdRepo.UpdateStatus(ctx, id, "archive")
+}
+
 func (s *RentAdService) GetFilteredRentsAd(ctx context.Context, filter models.RentAdFilterRequest, userID int) (models.RentAdListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1

--- a/internal/services/rent_service.go
+++ b/internal/services/rent_service.go
@@ -49,6 +49,10 @@ func (s *RentService) DeleteRent(ctx context.Context, id int) error {
 	return s.RentRepo.DeleteRent(ctx, id)
 }
 
+func (s *RentService) ArchiveRent(ctx context.Context, id int) error {
+	return s.RentRepo.UpdateStatus(ctx, id, "archive")
+}
+
 func (s *RentService) GetFilteredRents(ctx context.Context, filter models.RentFilterRequest, userID int) (models.RentListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1

--- a/internal/services/service_service.go
+++ b/internal/services/service_service.go
@@ -49,6 +49,10 @@ func (s *ServiceService) DeleteService(ctx context.Context, id int) error {
 	return s.ServiceRepo.DeleteService(ctx, id)
 }
 
+func (s *ServiceService) ArchiveService(ctx context.Context, id int) error {
+	return s.ServiceRepo.UpdateStatus(ctx, id, "archive")
+}
+
 func (s *ServiceService) GetFilteredServices(ctx context.Context, filter models.ServiceFilterRequest, userID int) (models.ServiceListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1

--- a/internal/services/work_ad_service.go
+++ b/internal/services/work_ad_service.go
@@ -26,6 +26,10 @@ func (s *WorkAdService) DeleteWorkAd(ctx context.Context, id int) error {
 	return s.WorkAdRepo.DeleteWorkAd(ctx, id)
 }
 
+func (s *WorkAdService) ArchiveWorkAd(ctx context.Context, id int) error {
+	return s.WorkAdRepo.UpdateStatus(ctx, id, "archive")
+}
+
 func (s *WorkAdService) GetFilteredWorksAd(ctx context.Context, filter models.WorkAdFilterRequest, userID int) (models.WorkAdListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1

--- a/internal/services/work_service.go
+++ b/internal/services/work_service.go
@@ -49,6 +49,10 @@ func (s *WorkService) DeleteWork(ctx context.Context, id int) error {
 	return s.WorkRepo.DeleteWork(ctx, id)
 }
 
+func (s *WorkService) ArchiveWork(ctx context.Context, id int) error {
+	return s.WorkRepo.UpdateStatus(ctx, id, "archive")
+}
+
 func (s *WorkService) GetFilteredWorks(ctx context.Context, filter models.WorkFilterRequest, userID int) (models.WorkListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1


### PR DESCRIPTION
## Summary
- add `/service/archive`, `/ad/archive`, `/rent/archive`, `/rent_ad/archive`, `/work/archive`, and `/work_ad/archive` endpoints
- support updating status to `archive` via repositories and services

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a6c001e9388324a74c584c10ba9498