### PR TITLE
Add reviewer info to review APIs

### DIFF
--- a/internal/models/ad_reviews.go
+++ b/internal/models/ad_reviews.go
@@ -5,11 +5,14 @@ import (
 )
 
 type AdReviews struct {
-	ID        int        `json:"id"`
-	UserID    int        `json:"user_id,omitempty"`
-	AdID      int        `json:"ad_id,omitempty"`
-	Rating    float64    `json:"rating"`
-	Review    string     `json:"review"`
-	CreatedAt time.Time  `json:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID             int        `json:"id"`
+	UserID         int        `json:"user_id,omitempty"`
+	AdID           int        `json:"ad_id,omitempty"`
+	Rating         float64    `json:"rating"`
+	Review         string     `json:"review"`
+	UserName       string     `json:"user_name"`
+	UserSurname    string     `json:"user_surname"`
+	UserAvatarPath *string    `json:"user_avatar_path"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
 }

--- a/internal/models/rent_ad_reviews.go
+++ b/internal/models/rent_ad_reviews.go
@@ -5,11 +5,14 @@ import (
 )
 
 type RentAdReviews struct {
-	ID        int        `json:"id"`
-	UserID    int        `json:"user_id,omitempty"`
-	RentAdID  int        `json:"rent_ad_id,omitempty"`
-	Rating    float64    `json:"rating"`
-	Review    string     `json:"review"`
-	CreatedAt time.Time  `json:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID             int        `json:"id"`
+	UserID         int        `json:"user_id,omitempty"`
+	RentAdID       int        `json:"rent_ad_id,omitempty"`
+	Rating         float64    `json:"rating"`
+	Review         string     `json:"review"`
+	UserName       string     `json:"user_name"`
+	UserSurname    string     `json:"user_surname"`
+	UserAvatarPath *string    `json:"user_avatar_path"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
 }

--- a/internal/models/rent_reviews.go
+++ b/internal/models/rent_reviews.go
@@ -5,11 +5,14 @@ import (
 )
 
 type RentReviews struct {
-	ID        int        `json:"id"`
-	UserID    int        `json:"user_id,omitempty"`
-	RentID    int        `json:"rent_id,omitempty"`
-	Rating    float64    `json:"rating"`
-	Review    string     `json:"review"`
-	CreatedAt time.Time  `json:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID             int        `json:"id"`
+	UserID         int        `json:"user_id,omitempty"`
+	RentID         int        `json:"rent_id,omitempty"`
+	Rating         float64    `json:"rating"`
+	Review         string     `json:"review"`
+	UserName       string     `json:"user_name"`
+	UserSurname    string     `json:"user_surname"`
+	UserAvatarPath *string    `json:"user_avatar_path"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
 }

--- a/internal/models/reviews.go
+++ b/internal/models/reviews.go
@@ -5,11 +5,14 @@ import (
 )
 
 type Reviews struct {
-	ID        int        `json:"id"`
-	UserID    int        `json:"user_id,omitempty"`
-	ServiceID int        `json:"service_id,omitempty"`
-	Rating    float64    `json:"rating"`
-	Review    string     `json:"review"`
-	CreatedAt time.Time  `json:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID             int        `json:"id"`
+	UserID         int        `json:"user_id,omitempty"`
+	ServiceID      int        `json:"service_id,omitempty"`
+	Rating         float64    `json:"rating"`
+	Review         string     `json:"review"`
+	UserName       string     `json:"user_name"`
+	UserSurname    string     `json:"user_surname"`
+	UserAvatarPath *string    `json:"user_avatar_path"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
 }

--- a/internal/models/work_ad_reviews.go
+++ b/internal/models/work_ad_reviews.go
@@ -5,11 +5,14 @@ import (
 )
 
 type WorkAdReviews struct {
-	ID        int        `json:"id"`
-	UserID    int        `json:"user_id,omitempty"`
-	WorkAdID  int        `json:"work_ad_id,omitempty"`
-	Rating    float64    `json:"rating"`
-	Review    string     `json:"review"`
-	CreatedAt time.Time  `json:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID             int        `json:"id"`
+	UserID         int        `json:"user_id,omitempty"`
+	WorkAdID       int        `json:"work_ad_id,omitempty"`
+	Rating         float64    `json:"rating"`
+	Review         string     `json:"review"`
+	UserName       string     `json:"user_name"`
+	UserSurname    string     `json:"user_surname"`
+	UserAvatarPath *string    `json:"user_avatar_path"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
 }

--- a/internal/models/work_reviews.go
+++ b/internal/models/work_reviews.go
@@ -5,11 +5,14 @@ import (
 )
 
 type WorkReviews struct {
-	ID        int        `json:"id"`
-	UserID    int        `json:"user_id,omitempty"`
-	WorkID    int        `json:"work_id,omitempty"`
-	Rating    float64    `json:"rating"`
-	Review    string     `json:"review"`
-	CreatedAt time.Time  `json:"created_at"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	ID             int        `json:"id"`
+	UserID         int        `json:"user_id,omitempty"`
+	WorkID         int        `json:"work_id,omitempty"`
+	Rating         float64    `json:"rating"`
+	Review         string     `json:"review"`
+	UserName       string     `json:"user_name"`
+	UserSurname    string     `json:"user_surname"`
+	UserAvatarPath *string    `json:"user_avatar_path"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      *time.Time `json:"updated_at,omitempty"`
 }

--- a/internal/repositories/ad_reviews_repository.go
+++ b/internal/repositories/ad_reviews_repository.go
@@ -31,11 +31,14 @@ func (r *AdReviewRepository) CreateAdReview(ctx context.Context, rev models.AdRe
 
 func (r *AdReviewRepository) GetReviewsByAdID(ctx context.Context, adID int) ([]models.AdReviews, error) {
 	query := `
-		SELECT id, user_id, ad_id, rating, review, created_at, updated_at
-		FROM ad_reviews
-		WHERE ad_id = ?
-		ORDER BY created_at DESC
-	`
+               SELECT ar.id, ar.user_id, ar.ad_id, ar.rating, ar.review,
+                      u.name, u.surname, u.avatar_path,
+                      ar.created_at, ar.updated_at
+               FROM ad_reviews ar
+               JOIN users u ON ar.user_id = u.id
+               WHERE ar.ad_id = ?
+               ORDER BY ar.created_at DESC
+       `
 	rows, err := r.DB.QueryContext(ctx, query, adID)
 	if err != nil {
 		return nil, err
@@ -45,9 +48,14 @@ func (r *AdReviewRepository) GetReviewsByAdID(ctx context.Context, adID int) ([]
 	reviews := []models.AdReviews{}
 	for rows.Next() {
 		var rev models.AdReviews
-		err := rows.Scan(&rev.ID, &rev.UserID, &rev.AdID, &rev.Rating, &rev.Review, &rev.CreatedAt, &rev.UpdatedAt)
+		err := rows.Scan(&rev.ID, &rev.UserID, &rev.AdID, &rev.Rating, &rev.Review,
+			&rev.UserName, &rev.UserSurname, &rev.UserAvatarPath,
+			&rev.CreatedAt, &rev.UpdatedAt)
 		if err != nil {
 			return nil, err
+		}
+		if rev.UserAvatarPath != nil && *rev.UserAvatarPath == "" {
+			rev.UserAvatarPath = nil
 		}
 		reviews = append(reviews, rev)
 	}

--- a/internal/repositories/review_repository.go
+++ b/internal/repositories/review_repository.go
@@ -31,11 +31,14 @@ func (r *ReviewRepository) CreateReview(ctx context.Context, rev models.Reviews)
 
 func (r *ReviewRepository) GetReviewsByServiceID(ctx context.Context, serviceID int) ([]models.Reviews, error) {
 	query := `
-		SELECT id, user_id, service_id, rating, review, created_at, updated_at
-		FROM reviews
-		WHERE service_id = ?
-		ORDER BY created_at DESC
-	`
+               SELECT r.id, r.user_id, r.service_id, r.rating, r.review,
+                      u.name, u.surname, u.avatar_path,
+                      r.created_at, r.updated_at
+               FROM reviews r
+               JOIN users u ON r.user_id = u.id
+               WHERE r.service_id = ?
+               ORDER BY r.created_at DESC
+       `
 	rows, err := r.DB.QueryContext(ctx, query, serviceID)
 	if err != nil {
 		return nil, err
@@ -45,9 +48,14 @@ func (r *ReviewRepository) GetReviewsByServiceID(ctx context.Context, serviceID 
 	reviews := []models.Reviews{}
 	for rows.Next() {
 		var rev models.Reviews
-		err := rows.Scan(&rev.ID, &rev.UserID, &rev.ServiceID, &rev.Rating, &rev.Review, &rev.CreatedAt, &rev.UpdatedAt)
+		err := rows.Scan(&rev.ID, &rev.UserID, &rev.ServiceID, &rev.Rating, &rev.Review,
+			&rev.UserName, &rev.UserSurname, &rev.UserAvatarPath,
+			&rev.CreatedAt, &rev.UpdatedAt)
 		if err != nil {
 			return nil, err
+		}
+		if rev.UserAvatarPath != nil && *rev.UserAvatarPath == "" {
+			rev.UserAvatarPath = nil
 		}
 		reviews = append(reviews, rev)
 	}

--- a/internal/repositories/work_ad_review_repository.go
+++ b/internal/repositories/work_ad_review_repository.go
@@ -31,11 +31,14 @@ func (r *WorkAdReviewRepository) CreateWorkAdReview(ctx context.Context, rev mod
 
 func (r *WorkAdReviewRepository) GetWorkAdReviewsByWorkID(ctx context.Context, workAdID int) ([]models.WorkAdReviews, error) {
 	query := `
-		SELECT id, user_id, work_ad_id, rating, review, created_at, updated_at
-		FROM work_ad_reviews
-		WHERE work_ad_id = ?
-		ORDER BY created_at DESC
-	`
+               SELECT war.id, war.user_id, war.work_ad_id, war.rating, war.review,
+                      u.name, u.surname, u.avatar_path,
+                      war.created_at, war.updated_at
+               FROM work_ad_reviews war
+               JOIN users u ON war.user_id = u.id
+               WHERE war.work_ad_id = ?
+               ORDER BY war.created_at DESC
+       `
 	rows, err := r.DB.QueryContext(ctx, query, workAdID)
 	if err != nil {
 		return nil, err
@@ -45,9 +48,14 @@ func (r *WorkAdReviewRepository) GetWorkAdReviewsByWorkID(ctx context.Context, w
 	reviews := []models.WorkAdReviews{}
 	for rows.Next() {
 		var rev models.WorkAdReviews
-		err := rows.Scan(&rev.ID, &rev.UserID, &rev.WorkAdID, &rev.Rating, &rev.Review, &rev.CreatedAt, &rev.UpdatedAt)
+		err := rows.Scan(&rev.ID, &rev.UserID, &rev.WorkAdID, &rev.Rating, &rev.Review,
+			&rev.UserName, &rev.UserSurname, &rev.UserAvatarPath,
+			&rev.CreatedAt, &rev.UpdatedAt)
 		if err != nil {
 			return nil, err
+		}
+		if rev.UserAvatarPath != nil && *rev.UserAvatarPath == "" {
+			rev.UserAvatarPath = nil
 		}
 		reviews = append(reviews, rev)
 	}


### PR DESCRIPTION
## Summary
- expose reviewer name, surname and avatar in review models
- join review queries with users table to populate reviewer fields
- return null for reviewer avatar when absent

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68ac0e7684288324bfc988712440f8f1