### PR TITLE
feat: add endpoint to retrieve user active orders

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -50,6 +50,7 @@ func (app *application) routes() http.Handler {
 	mux.Get("/user/posts/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetPostsByUserID))
 	mux.Get("/user/ads/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetAdsByUserID))
 	mux.Get("/user/orders/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetOrderHistoryByUserID))
+	mux.Get("/user/active_orders/:user_id", authMiddleware.ThenFunc(app.userItemsHandler.GetActiveOrdersByUserID))
 
 	mux.Get("/ads", standardMiddleware.ThenFunc(app.adHandler.GetAds))
 

--- a/internal/handlers/user_items_handler.go
+++ b/internal/handlers/user_items_handler.go
@@ -69,3 +69,22 @@ func (h *UserItemsHandler) GetOrderHistoryByUserID(w http.ResponseWriter, r *htt
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(items)
 }
+
+// GetActiveOrdersByUserID returns all active orders where the user is performer.
+func (h *UserItemsHandler) GetActiveOrdersByUserID(w http.ResponseWriter, r *http.Request) {
+	userIDStr := r.URL.Query().Get(":user_id")
+	userID, err := strconv.Atoi(userIDStr)
+	if err != nil {
+		http.Error(w, "invalid user_id", http.StatusBadRequest)
+		return
+	}
+
+	items, err := h.Service.GetActiveOrdersByUserID(r.Context(), userID)
+	if err != nil {
+		http.Error(w, "failed to get items", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(items)
+}

--- a/internal/repositories/user_items_repository.go
+++ b/internal/repositories/user_items_repository.go
@@ -95,3 +95,54 @@ func (r *UserItemsRepository) GetOrderHistoryByUserID(ctx context.Context, userI
 	}
 	return items, rows.Err()
 }
+
+// GetActiveOrdersByUserID returns all active orders where the user is the performer.
+func (r *UserItemsRepository) GetActiveOrdersByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
+	query := `
+    SELECT s.id, s.name, s.price, s.description, s.created_at, 'service' AS type
+    FROM service_confirmations sc
+    JOIN service s ON s.id = sc.service_id
+    WHERE sc.performer_id = ? AND sc.confirmed = true AND s.status = 'active'
+    UNION ALL
+    SELECT w.id, w.name, w.price, w.description, w.created_at, 'work' AS type
+    FROM work_confirmations wc
+    JOIN work w ON w.id = wc.work_id
+    WHERE wc.performer_id = ? AND wc.confirmed = true AND w.status = 'active'
+    UNION ALL
+    SELECT r.id, r.name, r.price, r.description, r.created_at, 'rent' AS type
+    FROM rent_confirmations rc
+    JOIN rent r ON r.id = rc.rent_id
+    WHERE rc.performer_id = ? AND rc.confirmed = true AND r.status = 'active'
+    UNION ALL
+    SELECT a.id, a.name, a.price, a.description, a.created_at, 'ad' AS type
+    FROM ad_confirmations ac
+    JOIN ad a ON a.id = ac.ad_id
+    WHERE ac.performer_id = ? AND ac.confirmed = true AND a.status = 'active'
+    UNION ALL
+    SELECT wa.id, wa.name, wa.price, wa.description, wa.created_at, 'work_ad' AS type
+    FROM work_ad_confirmations wac
+    JOIN work_ad wa ON wa.id = wac.work_ad_id
+    WHERE wac.performer_id = ? AND wac.confirmed = true AND wa.status = 'active'
+    UNION ALL
+    SELECT ra.id, ra.name, ra.price, ra.description, ra.created_at, 'rent_ad' AS type
+    FROM rent_ad_confirmations rac
+    JOIN rent_ad ra ON ra.id = rac.rent_ad_id
+    WHERE rac.performer_id = ? AND rac.confirmed = true AND ra.status = 'active'
+    ORDER BY created_at DESC`
+
+	rows, err := r.DB.QueryContext(ctx, query, userID, userID, userID, userID, userID, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []models.UserItem
+	for rows.Next() {
+		var item models.UserItem
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Type); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/services/user_items_service.go
+++ b/internal/services/user_items_service.go
@@ -26,3 +26,8 @@ func (s *UserItemsService) GetAdWorkAdRentAdByUserID(ctx context.Context, userID
 func (s *UserItemsService) GetOrderHistoryByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
 	return s.ItemsRepo.GetOrderHistoryByUserID(ctx, userID)
 }
+
+// GetActiveOrdersByUserID fetches active orders where the user is performer.
+func (s *UserItemsService) GetActiveOrdersByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
+	return s.ItemsRepo.GetActiveOrdersByUserID(ctx, userID)
+}


### PR DESCRIPTION
## Summary
- add repository query to collect active orders for a performer across different entity types
- expose service, handler, and router endpoint `/user/active_orders/:user_id`

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b051bc21d883248e242f9522e261e9