### PR TITLE
feat: expose responders API

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -63,6 +63,8 @@ type application struct {
 	serviceConfirmationRepo    *repositories.ServiceConfirmationRepository
 	userResponsesHandler       *handlers.UserResponsesHandler
 	userResponsesRepo          *repositories.UserResponsesRepository
+	responseUsersHandler       *handlers.ResponseUsersHandler
+	responseUsersRepo          *repositories.ResponseUsersRepository
 	userReviewsHandler         *handlers.UserReviewsHandler
 	userReviewsRepo            *repositories.UserReviewsRepository
 	userItemsHandler           *handlers.UserItemsHandler
@@ -154,6 +156,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	userResponsesRepo := repositories.UserResponsesRepository{DB: db}
 	userReviewsRepo := repositories.UserReviewsRepository{DB: db}
 	userItemsRepo := repositories.UserItemsRepository{DB: db}
+	responseUsersRepo := repositories.ResponseUsersRepository{DB: db}
 	workRepo := repositories.WorkRepository{DB: db}
 	rentRepo := repositories.RentRepository{DB: db}
 	workReviewRepo := repositories.WorkReviewRepository{DB: db}
@@ -204,6 +207,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	userResponsesService := &services.UserResponsesService{ResponsesRepo: &userResponsesRepo}
 	userReviewsService := &services.UserReviewsService{ReviewsRepo: &userReviewsRepo}
 	userItemsService := &services.UserItemsService{ItemsRepo: &userItemsRepo}
+	responseUsersService := &services.ResponseUsersService{Repo: &responseUsersRepo}
 	workService := &services.WorkService{WorkRepo: &workRepo, SubscriptionRepo: &subscriptionRepo}
 	rentService := &services.RentService{RentRepo: &rentRepo, SubscriptionRepo: &subscriptionRepo}
 	workReviewService := &services.WorkReviewService{WorkReviewsRepo: &workReviewRepo}
@@ -266,6 +270,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	userResponsesHandler := &handlers.UserResponsesHandler{Service: userResponsesService}
 	userReviewsHandler := &handlers.UserReviewsHandler{Service: userReviewsService}
 	userItemsHandler := &handlers.UserItemsHandler{Service: userItemsService}
+	responseUsersHandler := &handlers.ResponseUsersHandler{Service: responseUsersService}
 	workHandler := &handlers.WorkHandler{Service: workService}
 	rentHandler := &handlers.RentHandler{Service: rentService}
 	workReviewHandler := &handlers.WorkReviewHandler{Service: workReviewService}
@@ -334,6 +339,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		serviceResponseRepo:     &serviceResponseRepo,
 		serviceConfirmationRepo: &serviceConfirmationRepo,
 		userResponsesRepo:       &userResponsesRepo,
+		responseUsersRepo:       &responseUsersRepo,
 		userReviewsRepo:         &userReviewsRepo,
 		userItemsRepo:           &userItemsRepo,
 		workRepo:                &workRepo,
@@ -388,6 +394,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		serviceResponseHandler:     serviceResponseHandler,
 		serviceConfirmationHandler: serviceConfirmationHandler,
 		userResponsesHandler:       userResponsesHandler,
+		responseUsersHandler:       responseUsersHandler,
 		userReviewsHandler:         userReviewsHandler,
 		userItemsHandler:           userItemsHandler,
 		workHandler:                workHandler,

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -197,6 +197,7 @@ func (app *application) routes() http.Handler {
 	// Service Response
 	mux.Post("/responses", authMiddleware.ThenFunc(app.serviceResponseHandler.CreateServiceResponse))
 	mux.Get("/responses/:user_id", authMiddleware.ThenFunc(app.userResponsesHandler.GetResponsesByUserID))
+	mux.Get("/responses/item/:type/:item_id", authMiddleware.ThenFunc(app.responseUsersHandler.GetUsersByItemID))
 
 	// Work
 	mux.Post("/work", authMiddleware.ThenFunc(app.workHandler.CreateWork))

--- a/internal/handlers/response_users_handler.go
+++ b/internal/handlers/response_users_handler.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/services"
+)
+
+// ResponseUsersHandler handles HTTP requests for retrieving users who responded to items.
+type ResponseUsersHandler struct {
+	Service *services.ResponseUsersService
+}
+
+// GetUsersByItemID returns users who responded to a specific item.
+func (h *ResponseUsersHandler) GetUsersByItemID(w http.ResponseWriter, r *http.Request) {
+	itemType := r.URL.Query().Get(":type")
+	idStr := r.URL.Query().Get(":item_id")
+	itemID, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid item_id", http.StatusBadRequest)
+		return
+	}
+
+	users, err := h.Service.GetUsersByItemID(r.Context(), itemType, itemID)
+	if err != nil {
+		http.Error(w, "failed to get users", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(users)
+}

--- a/internal/models/response_users.go
+++ b/internal/models/response_users.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+// ResponseUser represents a user who responded to an item along with response details.
+type ResponseUser struct {
+	ID          int       `json:"id"`
+	Name        string    `json:"name"`
+	Surname     string    `json:"surname"`
+	AvatarPath  *string   `json:"avatar_path,omitempty"`
+	Rating      float64   `json:"rating"`
+	Price       float64   `json:"price"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/repositories/response_users_repository.go
+++ b/internal/repositories/response_users_repository.go
@@ -1,0 +1,78 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"naimuBack/internal/models"
+)
+
+// ResponseUsersRepository retrieves users who responded to items.
+type ResponseUsersRepository struct {
+	DB *sql.DB
+}
+
+// GetUsersByItemID returns users who responded to a specific item type.
+func (r *ResponseUsersRepository) GetUsersByItemID(ctx context.Context, itemType string, itemID int) ([]models.ResponseUser, error) {
+	var query string
+	switch itemType {
+	case "service":
+		query = `
+            SELECT u.id, u.name, u.surname, u.avatar_path, u.review_rating, sr.price, sr.description, sr.created_at
+            FROM service_responses sr
+            JOIN users u ON u.id = sr.user_id
+            WHERE sr.service_id = ?`
+	case "ad":
+		query = `
+            SELECT u.id, u.name, u.surname, u.avatar_path, u.review_rating, ar.price, ar.description, ar.created_at
+            FROM ad_responses ar
+            JOIN users u ON u.id = ar.user_id
+            WHERE ar.ad_id = ?`
+	case "work":
+		query = `
+            SELECT u.id, u.name, u.surname, u.avatar_path, u.review_rating, wr.price, wr.description, wr.created_at
+            FROM work_responses wr
+            JOIN users u ON u.id = wr.user_id
+            WHERE wr.work_id = ?`
+	case "work_ad":
+		query = `
+            SELECT u.id, u.name, u.surname, u.avatar_path, u.review_rating, war.price, war.description, war.created_at
+            FROM work_ad_responses war
+            JOIN users u ON u.id = war.user_id
+            WHERE war.work_ad_id = ?`
+	case "rent":
+		query = `
+            SELECT u.id, u.name, u.surname, u.avatar_path, u.review_rating, rr.price, rr.description, rr.created_at
+            FROM rent_responses rr
+            JOIN users u ON u.id = rr.user_id
+            WHERE rr.rent_id = ?`
+	case "rent_ad":
+		query = `
+            SELECT u.id, u.name, u.surname, u.avatar_path, u.review_rating, rar.price, rar.description, rar.created_at
+            FROM rent_ad_responses rar
+            JOIN users u ON u.id = rar.user_id
+            WHERE rar.rent_ad_id = ?`
+	default:
+		return nil, errors.New("unknown item type")
+	}
+
+	rows, err := r.DB.QueryContext(ctx, query, itemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []models.ResponseUser
+	for rows.Next() {
+		var u models.ResponseUser
+		if err := rows.Scan(&u.ID, &u.Name, &u.Surname, &u.AvatarPath, &u.Rating, &u.Price, &u.Description, &u.CreatedAt); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return users, nil
+}

--- a/internal/services/response_users_service.go
+++ b/internal/services/response_users_service.go
@@ -1,0 +1,18 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+// ResponseUsersService provides business logic for retrieving users who responded to items.
+type ResponseUsersService struct {
+	Repo *repositories.ResponseUsersRepository
+}
+
+// GetUsersByItemID fetches users who responded to the given item type and ID.
+func (s *ResponseUsersService) GetUsersByItemID(ctx context.Context, itemType string, itemID int) ([]models.ResponseUser, error) {
+	return s.Repo.GetUsersByItemID(ctx, itemType, itemID)
+}


### PR DESCRIPTION
## Summary
- add ResponseUser model and repository to query responders by item type
- expose GET /responses/item/:type/:item_id for fetching responder info

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0557806648324944d67ea82551c5a