### PR TITLE
feat: expose responders API and add coordinates to filtered results

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -63,6 +63,8 @@ type application struct {
 	serviceConfirmationRepo    *repositories.ServiceConfirmationRepository
 	userResponsesHandler       *handlers.UserResponsesHandler
 	userResponsesRepo          *repositories.UserResponsesRepository
+	responseUsersHandler       *handlers.ResponseUsersHandler
+	responseUsersRepo          *repositories.ResponseUsersRepository
 	userReviewsHandler         *handlers.UserReviewsHandler
 	userReviewsRepo            *repositories.UserReviewsRepository
 	userItemsHandler           *handlers.UserItemsHandler
@@ -154,6 +156,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	userResponsesRepo := repositories.UserResponsesRepository{DB: db}
 	userReviewsRepo := repositories.UserReviewsRepository{DB: db}
 	userItemsRepo := repositories.UserItemsRepository{DB: db}
+	responseUsersRepo := repositories.ResponseUsersRepository{DB: db}
 	workRepo := repositories.WorkRepository{DB: db}
 	rentRepo := repositories.RentRepository{DB: db}
 	workReviewRepo := repositories.WorkReviewRepository{DB: db}
@@ -204,6 +207,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	userResponsesService := &services.UserResponsesService{ResponsesRepo: &userResponsesRepo}
 	userReviewsService := &services.UserReviewsService{ReviewsRepo: &userReviewsRepo}
 	userItemsService := &services.UserItemsService{ItemsRepo: &userItemsRepo}
+	responseUsersService := &services.ResponseUsersService{Repo: &responseUsersRepo}
 	workService := &services.WorkService{WorkRepo: &workRepo, SubscriptionRepo: &subscriptionRepo}
 	rentService := &services.RentService{RentRepo: &rentRepo, SubscriptionRepo: &subscriptionRepo}
 	workReviewService := &services.WorkReviewService{WorkReviewsRepo: &workReviewRepo}
@@ -266,6 +270,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	userResponsesHandler := &handlers.UserResponsesHandler{Service: userResponsesService}
 	userReviewsHandler := &handlers.UserReviewsHandler{Service: userReviewsService}
 	userItemsHandler := &handlers.UserItemsHandler{Service: userItemsService}
+	responseUsersHandler := &handlers.ResponseUsersHandler{Service: responseUsersService}
 	workHandler := &handlers.WorkHandler{Service: workService}
 	rentHandler := &handlers.RentHandler{Service: rentService}
 	workReviewHandler := &handlers.WorkReviewHandler{Service: workReviewService}
@@ -334,6 +339,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		serviceResponseRepo:     &serviceResponseRepo,
 		serviceConfirmationRepo: &serviceConfirmationRepo,
 		userResponsesRepo:       &userResponsesRepo,
+		responseUsersRepo:       &responseUsersRepo,
 		userReviewsRepo:         &userReviewsRepo,
 		userItemsRepo:           &userItemsRepo,
 		workRepo:                &workRepo,
@@ -388,6 +394,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 		serviceResponseHandler:     serviceResponseHandler,
 		serviceConfirmationHandler: serviceConfirmationHandler,
 		userResponsesHandler:       userResponsesHandler,
+		responseUsersHandler:       responseUsersHandler,
 		userReviewsHandler:         userReviewsHandler,
 		userItemsHandler:           userItemsHandler,
 		workHandler:                workHandler,

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -197,6 +197,7 @@ func (app *application) routes() http.Handler {
 	// Service Response
 	mux.Post("/responses", authMiddleware.ThenFunc(app.serviceResponseHandler.CreateServiceResponse))
 	mux.Get("/responses/:user_id", authMiddleware.ThenFunc(app.userResponsesHandler.GetResponsesByUserID))
+	mux.Get("/responses/item/:type/:item_id", authMiddleware.ThenFunc(app.responseUsersHandler.GetUsersByItemID))
 
 	// Work
 	mux.Post("/work", authMiddleware.ThenFunc(app.workHandler.CreateWork))

--- a/internal/handlers/response_users_handler.go
+++ b/internal/handlers/response_users_handler.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"naimuBack/internal/services"
+)
+
+// ResponseUsersHandler handles HTTP requests for retrieving users who responded to items.
+type ResponseUsersHandler struct {
+	Service *services.ResponseUsersService
+}
+
+// GetUsersByItemID returns users who responded to a specific item.
+func (h *ResponseUsersHandler) GetUsersByItemID(w http.ResponseWriter, r *http.Request) {
+	itemType := r.URL.Query().Get(":type")
+	idStr := r.URL.Query().Get(":item_id")
+	itemID, err := strconv.Atoi(idStr)
+	if err != nil {
+		http.Error(w, "invalid item_id", http.StatusBadRequest)
+		return
+	}
+
+	users, err := h.Service.GetUsersByItemID(r.Context(), itemType, itemID)
+	if err != nil {
+		http.Error(w, "failed to get users", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(users)
+}

--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -81,6 +81,8 @@ type FilteredAd struct {
 	AdName           string  `json:"ad_name"`
 	AdPrice          float64 `json:"ad_price"`
 	AdDescription    string  `json:"ad_description"`
+	AdLatitude       *string `json:"latitude"`
+	AdLongitude      *string `json:"longitude"`
 	Liked            bool    `json:"liked"`
 	Responded        bool    `json:"is_responded"`
 }

--- a/internal/models/rent.go
+++ b/internal/models/rent.go
@@ -83,6 +83,8 @@ type FilteredRent struct {
 	ServiceName        string  `json:"service_name"`
 	ServicePrice       float64 `json:"service_price"`
 	ServiceDescription string  `json:"service_description"`
+	ServiceLatitude    string  `json:"latitude"`
+	ServiceLongitude   string  `json:"longitude"`
 	Liked              bool    `json:"liked"`
 	Responded          bool    `json:"is_responded"`
 }

--- a/internal/models/rent_ad.go
+++ b/internal/models/rent_ad.go
@@ -83,6 +83,8 @@ type FilteredRentAd struct {
 	RentAdName        string  `json:"rentad_name"`
 	RentAdPrice       float64 `json:"rentad_price"`
 	RentAdDescription string  `json:"rentad_description"`
+	RentAdLatitude    string  `json:"latitude"`
+	RentAdLongitude   string  `json:"longitude"`
 	Liked             bool    `json:"liked"`
 	Responded         bool    `json:"is_responded"`
 }

--- a/internal/models/response_users.go
+++ b/internal/models/response_users.go
@@ -1,0 +1,15 @@
+package models
+
+import "time"
+
+// ResponseUser represents a user who responded to an item along with response details.
+type ResponseUser struct {
+	ID          int       `json:"id"`
+	Name        string    `json:"name"`
+	Surname     string    `json:"surname"`
+	AvatarPath  *string   `json:"avatar_path,omitempty"`
+	Rating      float64   `json:"rating"`
+	Price       float64   `json:"price"`
+	Description string    `json:"description"`
+	CreatedAt   time.Time `json:"created_at"`
+}

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -82,6 +82,8 @@ type FilteredService struct {
 	ServiceName        string  `json:"service_name"`
 	ServicePrice       float64 `json:"service_price"`
 	ServiceDescription string  `json:"service_description"`
+	ServiceLatitude    *string `json:"latitude"`
+	ServiceLongitude   *string `json:"longitude"`
 	Liked              bool    `json:"liked"`
 	Responded          bool    `json:"is_responded"`
 }

--- a/internal/models/work.go
+++ b/internal/models/work.go
@@ -88,6 +88,8 @@ type FilteredWork struct {
 	ServiceName        string  `json:"service_name"`
 	ServicePrice       float64 `json:"service_price"`
 	ServiceDescription string  `json:"service_description"`
+	ServiceLatitude    string  `json:"latitude"`
+	ServiceLongitude   string  `json:"longitude"`
 	Liked              bool    `json:"liked"`
 	Responded          bool    `json:"is_responded"`
 }

--- a/internal/models/work_ad.go
+++ b/internal/models/work_ad.go
@@ -88,6 +88,8 @@ type FilteredWorkAd struct {
 	WorkAdName        string  `json:"workad_name"`
 	WorkAdPrice       float64 `json:"workad_price"`
 	WorkAdDescription string  `json:"workad_description"`
+	WorkAdLatitude    string  `json:"latitude"`
+	WorkAdLongitude   string  `json:"longitude"`
 	Liked             bool    `json:"liked"`
 	Responded         bool    `json:"is_responded"`
 }

--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -334,8 +334,8 @@ func (r *AdRepository) GetAdByUserID(ctx context.Context, userID int) ([]models.
 func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterAdRequest) ([]models.FilteredAd, error) {
 	query := `
       SELECT
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-              s.id, s.name, s.price, s.description
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+              s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM ad s
       JOIN users u ON s.user_id = u.id
       WHERE 1=1
@@ -396,11 +396,18 @@ func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterA
 	var ads []models.FilteredAd
 	for rows.Next() {
 		var s models.FilteredAd
+		var lat, lon sql.NullString
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.AdID, &s.AdName, &s.AdPrice, &s.AdDescription,
+			&s.AdID, &s.AdName, &s.AdPrice, &s.AdDescription, &lat, &lon,
 		); err != nil {
 			return nil, err
+		}
+		if lat.Valid {
+			s.AdLatitude = &lat.String
+		}
+		if lon.Valid {
+			s.AdLongitude = &lon.String
 		}
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
@@ -458,8 +465,8 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 
 	query := `
    SELECT DISTINCT
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-           s.id, s.name, s.price, s.description,
+           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
            CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded
    FROM ad s
@@ -540,12 +547,19 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 	var ads []models.FilteredAd
 	for rows.Next() {
 		var s models.FilteredAd
+		var lat, lon sql.NullString
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.AdID, &s.AdName, &s.AdPrice, &s.AdDescription, &s.Liked, &s.Responded,
+			&s.AdID, &s.AdName, &s.AdPrice, &s.AdDescription, &lat, &lon, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+		if lat.Valid {
+			s.AdLatitude = &lat.String
+		}
+		if lon.Valid {
+			s.AdLongitude = &lon.String
 		}
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -328,8 +328,8 @@ func (r *RentAdRepository) GetRentsAdByUserID(ctx context.Context, userID int) (
 func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req models.FilterRentAdRequest) ([]models.FilteredRentAd, error) {
 	query := `
       SELECT
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-              s.id, s.name, s.price, s.description
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+              s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM rent_ad s
       JOIN users u ON s.user_id = u.id
       WHERE 1=1
@@ -392,7 +392,7 @@ func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req model
 		var s models.FilteredRentAd
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription,
+			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription, &s.RentAdLatitude, &s.RentAdLongitude,
 		); err != nil {
 			return nil, err
 		}
@@ -452,8 +452,8 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 
 	query := `
    SELECT DISTINCT
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-           s.id, s.name, s.price, s.description,
+           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
            CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded
    FROM rent_ad s
@@ -536,7 +536,7 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 		var s models.FilteredRentAd
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription, &s.Liked, &s.Responded,
+			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription, &s.RentAdLatitude, &s.RentAdLongitude, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -328,8 +328,8 @@ func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]mo
 func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.FilterRentRequest) ([]models.FilteredRent, error) {
 	query := `
       SELECT
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-              s.id, s.name, s.price, s.description
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+              s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM rent s
       JOIN users u ON s.user_id = u.id
       WHERE 1=1
@@ -392,7 +392,7 @@ func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.Fi
 		var s models.FilteredRent
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
+			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.ServiceLatitude, &s.ServiceLongitude,
 		); err != nil {
 			return nil, err
 		}
@@ -452,8 +452,8 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 
 	query := `
    SELECT DISTINCT
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-           s.id, s.name, s.price, s.description,
+           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
            CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded
    FROM rent s
@@ -536,7 +536,7 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 		var s models.FilteredRent
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked, &s.Responded,
+			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.ServiceLatitude, &s.ServiceLongitude, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)

--- a/internal/repositories/response_users_repository.go
+++ b/internal/repositories/response_users_repository.go
@@ -1,0 +1,78 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"naimuBack/internal/models"
+)
+
+// ResponseUsersRepository retrieves users who responded to items.
+type ResponseUsersRepository struct {
+	DB *sql.DB
+}
+
+// GetUsersByItemID returns users who responded to a specific item type.
+func (r *ResponseUsersRepository) GetUsersByItemID(ctx context.Context, itemType string, itemID int) ([]models.ResponseUser, error) {
+	var query string
+	switch itemType {
+	case "service":
+		query = `
+            SELECT u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0), sr.price, sr.description, sr.created_at
+            FROM service_responses sr
+            JOIN users u ON u.id = sr.user_id
+            WHERE sr.service_id = ?`
+	case "ad":
+		query = `
+            SELECT u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0), ar.price, ar.description, ar.created_at
+            FROM ad_responses ar
+            JOIN users u ON u.id = ar.user_id
+            WHERE ar.ad_id = ?`
+	case "work":
+		query = `
+            SELECT u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0), wr.price, wr.description, wr.created_at
+            FROM work_responses wr
+            JOIN users u ON u.id = wr.user_id
+            WHERE wr.work_id = ?`
+	case "work_ad":
+		query = `
+            SELECT u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0), war.price, war.description, war.created_at
+            FROM work_ad_responses war
+            JOIN users u ON u.id = war.user_id
+            WHERE war.work_ad_id = ?`
+	case "rent":
+		query = `
+            SELECT u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0), rr.price, rr.description, rr.created_at
+            FROM rent_responses rr
+            JOIN users u ON u.id = rr.user_id
+            WHERE rr.rent_id = ?`
+	case "rent_ad":
+		query = `
+            SELECT u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0), rar.price, rar.description, rar.created_at
+            FROM rent_ad_responses rar
+            JOIN users u ON u.id = rar.user_id
+            WHERE rar.rent_ad_id = ?`
+	default:
+		return nil, errors.New("unknown item type")
+	}
+
+	rows, err := r.DB.QueryContext(ctx, query, itemID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var users []models.ResponseUser
+	for rows.Next() {
+		var u models.ResponseUser
+		if err := rows.Scan(&u.ID, &u.Name, &u.Surname, &u.AvatarPath, &u.Rating, &u.Price, &u.Description, &u.CreatedAt); err != nil {
+			return nil, err
+		}
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return users, nil
+}

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -335,8 +335,8 @@ func (r *ServiceRepository) GetServicesByUserID(ctx context.Context, userID int)
 func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req models.FilterServicesRequest) ([]models.FilteredService, error) {
 	query := `
       SELECT
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-              s.id, s.name, s.price, s.description
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+              s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM service s
       JOIN users u ON s.user_id = u.id
       WHERE 1=1
@@ -397,11 +397,18 @@ func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req mod
 	var services []models.FilteredService
 	for rows.Next() {
 		var s models.FilteredService
+		var lat, lon sql.NullString
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
+			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon,
 		); err != nil {
 			return nil, err
+		}
+		if lat.Valid {
+			s.ServiceLatitude = &lat.String
+		}
+		if lon.Valid {
+			s.ServiceLongitude = &lon.String
 		}
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {
@@ -459,8 +466,8 @@ func (r *ServiceRepository) GetFilteredServicesWithLikes(ctx context.Context, re
 
 	query := `
    SELECT DISTINCT
-          u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-          s.id, s.name, s.price, s.description,
+          u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+          s.id, s.name, s.price, s.description, s.latitude, s.longitude,
           CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
           CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded
    FROM service s
@@ -534,12 +541,19 @@ func (r *ServiceRepository) GetFilteredServicesWithLikes(ctx context.Context, re
 	var services []models.FilteredService
 	for rows.Next() {
 		var s models.FilteredService
+		var lat, lon sql.NullString
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked, &s.Responded,
+			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)
+		}
+		if lat.Valid {
+			s.ServiceLatitude = &lat.String
+		}
+		if lon.Valid {
+			s.ServiceLongitude = &lon.String
 		}
 		count, err := getUserTotalReviews(ctx, r.DB, s.UserID)
 		if err == nil {

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -334,8 +334,8 @@ func (r *WorkAdRepository) GetWorksAdByUserID(ctx context.Context, userID int) (
 func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req models.FilterWorkAdRequest) ([]models.FilteredWorkAd, error) {
 	query := `
       SELECT
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-              s.id, s.name, s.price, s.description
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+              s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM work_ad s
       JOIN users u ON s.user_id = u.id
       WHERE 1=1
@@ -398,7 +398,7 @@ func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req model
 		var s models.FilteredWorkAd
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.WorkAdID, &s.WorkAdName, &s.WorkAdPrice, &s.WorkAdDescription,
+			&s.WorkAdID, &s.WorkAdName, &s.WorkAdPrice, &s.WorkAdDescription, &s.WorkAdLatitude, &s.WorkAdLongitude,
 		); err != nil {
 			return nil, err
 		}
@@ -458,8 +458,8 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
 
 	query := `
    SELECT DISTINCT
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-           s.id, s.name, s.price, s.description,
+           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
            CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded
    FROM work_ad s
@@ -542,7 +542,7 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
 		var s models.FilteredWorkAd
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.WorkAdID, &s.WorkAdName, &s.WorkAdPrice, &s.WorkAdDescription, &s.Liked, &s.Responded,
+			&s.WorkAdID, &s.WorkAdName, &s.WorkAdPrice, &s.WorkAdDescription, &s.WorkAdLatitude, &s.WorkAdLongitude, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -344,8 +344,8 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.FilterWorkRequest) ([]models.FilteredWork, error) {
 	query := `
       SELECT
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-              s.id, s.name, s.price, s.description
+              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+              s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM work s
       JOIN users u ON s.user_id = u.id
       WHERE 1=1
@@ -408,7 +408,7 @@ func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.Fi
 		var s models.FilteredWork
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription,
+			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.ServiceLatitude, &s.ServiceLongitude,
 		); err != nil {
 			return nil, err
 		}
@@ -468,8 +468,8 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 
 	query := `
    SELECT DISTINCT
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), u.review_rating,
-           s.id, s.name, s.price, s.description,
+           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
            CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded
    FROM work s
@@ -552,7 +552,7 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 		var s models.FilteredWork
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.Liked, &s.Responded,
+			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.ServiceLatitude, &s.ServiceLongitude, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)

--- a/internal/services/response_users_service.go
+++ b/internal/services/response_users_service.go
@@ -1,0 +1,18 @@
+package services
+
+import (
+	"context"
+
+	"naimuBack/internal/models"
+	"naimuBack/internal/repositories"
+)
+
+// ResponseUsersService provides business logic for retrieving users who responded to items.
+type ResponseUsersService struct {
+	Repo *repositories.ResponseUsersRepository
+}
+
+// GetUsersByItemID fetches users who responded to the given item type and ID.
+func (s *ResponseUsersService) GetUsersByItemID(ctx context.Context, itemType string, itemID int) ([]models.ResponseUser, error) {
+	return s.Repo.GetUsersByItemID(ctx, itemType, itemID)
+}


### PR DESCRIPTION
## Summary
- add ResponseUser model and repository to query responders by item type
- expose GET /responses/item/:type/:item_id for fetching responder info
- include latitude and longitude in filtered service, work, ad, work ad, rent, and rent ad responses
- handle nullable coordinates when scanning filtered services and ads
- coalesce nullable user ratings in filtered queries to prevent fetch failures

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b0557806648324944d67ea82551c5a