### PR TITLE
Expand active orders endpoint to include pending and done statuses

### DIFF
--- a/internal/handlers/user_items_handler.go
+++ b/internal/handlers/user_items_handler.go
@@ -70,7 +70,7 @@ func (h *UserItemsHandler) GetOrderHistoryByUserID(w http.ResponseWriter, r *htt
 	json.NewEncoder(w).Encode(items)
 }
 
-// GetActiveOrdersByUserID returns all active orders where the user is performer.
+// GetActiveOrdersByUserID returns all orders with status active, pending, or done where the user is performer.
 func (h *UserItemsHandler) GetActiveOrdersByUserID(w http.ResponseWriter, r *http.Request) {
 	userIDStr := r.URL.Query().Get(":user_id")
 	userID, err := strconv.Atoi(userIDStr)

--- a/internal/repositories/user_items_repository.go
+++ b/internal/repositories/user_items_repository.go
@@ -96,38 +96,38 @@ func (r *UserItemsRepository) GetOrderHistoryByUserID(ctx context.Context, userI
 	return items, rows.Err()
 }
 
-// GetActiveOrdersByUserID returns all active orders where the user is the performer.
+// GetActiveOrdersByUserID returns all orders with status active, pending, or done where the user is the performer.
 func (r *UserItemsRepository) GetActiveOrdersByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
 	query := `
     SELECT s.id, s.name, s.price, s.description, s.created_at, 'service' AS type
     FROM service_confirmations sc
     JOIN service s ON s.id = sc.service_id
-    WHERE sc.performer_id = ? AND sc.confirmed = true AND s.status = 'active'
+    WHERE sc.performer_id = ? AND sc.confirmed = true AND s.status IN ('active', 'pending', 'done')
     UNION ALL
     SELECT w.id, w.name, w.price, w.description, w.created_at, 'work' AS type
     FROM work_confirmations wc
     JOIN work w ON w.id = wc.work_id
-    WHERE wc.performer_id = ? AND wc.confirmed = true AND w.status = 'active'
+    WHERE wc.performer_id = ? AND wc.confirmed = true AND w.status IN ('active', 'pending', 'done')
     UNION ALL
     SELECT r.id, r.name, r.price, r.description, r.created_at, 'rent' AS type
     FROM rent_confirmations rc
     JOIN rent r ON r.id = rc.rent_id
-    WHERE rc.performer_id = ? AND rc.confirmed = true AND r.status = 'active'
+    WHERE rc.performer_id = ? AND rc.confirmed = true AND r.status IN ('active', 'pending', 'done')
     UNION ALL
     SELECT a.id, a.name, a.price, a.description, a.created_at, 'ad' AS type
     FROM ad_confirmations ac
     JOIN ad a ON a.id = ac.ad_id
-    WHERE ac.performer_id = ? AND ac.confirmed = true AND a.status = 'active'
+    WHERE ac.performer_id = ? AND ac.confirmed = true AND a.status IN ('active', 'pending', 'done')
     UNION ALL
     SELECT wa.id, wa.name, wa.price, wa.description, wa.created_at, 'work_ad' AS type
     FROM work_ad_confirmations wac
     JOIN work_ad wa ON wa.id = wac.work_ad_id
-    WHERE wac.performer_id = ? AND wac.confirmed = true AND wa.status = 'active'
+    WHERE wac.performer_id = ? AND wac.confirmed = true AND wa.status IN ('active', 'pending', 'done')
     UNION ALL
     SELECT ra.id, ra.name, ra.price, ra.description, ra.created_at, 'rent_ad' AS type
     FROM rent_ad_confirmations rac
     JOIN rent_ad ra ON ra.id = rac.rent_ad_id
-    WHERE rac.performer_id = ? AND rac.confirmed = true AND ra.status = 'active'
+    WHERE rac.performer_id = ? AND rac.confirmed = true AND ra.status IN ('active', 'pending', 'done')
     ORDER BY created_at DESC`
 
 	rows, err := r.DB.QueryContext(ctx, query, userID, userID, userID, userID, userID, userID)

--- a/internal/services/user_items_service.go
+++ b/internal/services/user_items_service.go
@@ -27,7 +27,7 @@ func (s *UserItemsService) GetOrderHistoryByUserID(ctx context.Context, userID i
 	return s.ItemsRepo.GetOrderHistoryByUserID(ctx, userID)
 }
 
-// GetActiveOrdersByUserID fetches active orders where the user is performer.
+// GetActiveOrdersByUserID fetches orders with status active, pending, or done where the user is performer.
 func (s *UserItemsService) GetActiveOrdersByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
 	return s.ItemsRepo.GetActiveOrdersByUserID(ctx, userID)
 }


### PR DESCRIPTION
## Summary
- include pending and done statuses in active orders query
- document new statuses in service and handler comments

## Testing
- `go vet ./...` (struct tag warnings in models)
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b06854769883248ed4db2a8e846010