### PR TITLE
Include user city in JWT and city-based ad filtering

### DIFF
--- a/internal/handlers/rent_ad_handler.go
+++ b/internal/handlers/rent_ad_handler.go
@@ -126,7 +126,20 @@ func (h *RentAdHandler) GetRentsAd(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	result, err := h.Service.GetFilteredRentsAd(r.Context(), filter, 0)
+	cityID := 0
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			cityID = claims.CityID
+		}
+	}
+
+	result, err := h.Service.GetFilteredRentsAd(r.Context(), filter, 0, cityID)
 	if err != nil {
 		log.Printf("GetServices error: %v", err)
 		http.Error(w, "Failed to fetch services", http.StatusInternalServerError)
@@ -202,7 +215,7 @@ func (h *RentAdHandler) GetRentsAdSorted(w http.ResponseWriter, r *http.Request)
 		Limit:      limit,
 	}
 
-	result, err := h.Service.GetFilteredRentsAd(r.Context(), filter, userID)
+	result, err := h.Service.GetFilteredRentsAd(r.Context(), filter, userID, 0)
 	if err != nil {
 		http.Error(w, "Failed to get services", http.StatusInternalServerError)
 		return

--- a/internal/handlers/rent_handler.go
+++ b/internal/handlers/rent_handler.go
@@ -126,7 +126,20 @@ func (h *RentHandler) GetRents(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	result, err := h.Service.GetFilteredRents(r.Context(), filter, 0)
+	cityID := 0
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			cityID = claims.CityID
+		}
+	}
+
+	result, err := h.Service.GetFilteredRents(r.Context(), filter, 0, cityID)
 	if err != nil {
 		log.Printf("GetServices error: %v", err)
 		http.Error(w, "Failed to fetch services", http.StatusInternalServerError)
@@ -202,7 +215,7 @@ func (h *RentHandler) GetRentsSorted(w http.ResponseWriter, r *http.Request) {
 		Limit:      limit,
 	}
 
-	result, err := h.Service.GetFilteredRents(r.Context(), filter, userID)
+	result, err := h.Service.GetFilteredRents(r.Context(), filter, userID, 0)
 	if err != nil {
 		http.Error(w, "Failed to get services", http.StatusInternalServerError)
 		return

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -126,7 +126,20 @@ func (h *ServiceHandler) GetServices(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	result, err := h.Service.GetFilteredServices(r.Context(), filter, 0)
+	cityID := 0
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			cityID = claims.CityID
+		}
+	}
+
+	result, err := h.Service.GetFilteredServices(r.Context(), filter, 0, cityID)
 	if err != nil {
 		log.Printf("GetServices error: %v", err)
 		http.Error(w, "Failed to fetch services", http.StatusInternalServerError)
@@ -202,7 +215,7 @@ func (h *ServiceHandler) GetServicesSorted(w http.ResponseWriter, r *http.Reques
 		Limit:      limit,
 	}
 
-	result, err := h.Service.GetFilteredServices(r.Context(), filter, userID)
+	result, err := h.Service.GetFilteredServices(r.Context(), filter, userID, 0)
 	if err != nil {
 		http.Error(w, "Failed to get services", http.StatusInternalServerError)
 		return

--- a/internal/handlers/work_ad_handler.go
+++ b/internal/handlers/work_ad_handler.go
@@ -126,7 +126,20 @@ func (h *WorkAdHandler) GetWorksAd(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	result, err := h.Service.GetFilteredWorksAd(r.Context(), filter, 0)
+	cityID := 0
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			cityID = claims.CityID
+		}
+	}
+
+	result, err := h.Service.GetFilteredWorksAd(r.Context(), filter, 0, cityID)
 	if err != nil {
 		log.Printf("GetServices error: %v", err)
 		http.Error(w, "Failed to fetch services", http.StatusInternalServerError)
@@ -202,7 +215,20 @@ func (h *WorkAdHandler) GetWorksAdSorted(w http.ResponseWriter, r *http.Request)
 		Limit:      limit,
 	}
 
-	result, err := h.Service.GetFilteredWorksAd(r.Context(), filter, userID)
+	cityID := 0
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			cityID = claims.CityID
+		}
+	}
+
+	result, err := h.Service.GetFilteredWorksAd(r.Context(), filter, userID, cityID)
 	if err != nil {
 		http.Error(w, "Failed to get services", http.StatusInternalServerError)
 		return
@@ -236,6 +262,19 @@ func (h *WorkAdHandler) GetFilteredWorksAdPost(w http.ResponseWriter, r *http.Re
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	worksad, err := h.Service.GetFilteredWorksAdPost(r.Context(), req)
@@ -495,6 +534,19 @@ func (h *WorkAdHandler) GetFilteredWorksAdWithLikes(w http.ResponseWriter, r *ht
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	worksad, err := h.Service.GetFilteredWorksAdWithLikes(r.Context(), req, userID)

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -126,7 +126,20 @@ func (h *WorkHandler) GetWorks(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	result, err := h.Service.GetFilteredWorks(r.Context(), filter, 0)
+	cityID := 0
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			cityID = claims.CityID
+		}
+	}
+
+	result, err := h.Service.GetFilteredWorks(r.Context(), filter, 0, cityID)
 	if err != nil {
 		log.Printf("GetServices error: %v", err)
 		http.Error(w, "Failed to fetch services", http.StatusInternalServerError)
@@ -201,8 +214,20 @@ func (h *WorkHandler) GetWorksSorted(w http.ResponseWriter, r *http.Request) {
 		Page:       page,
 		Limit:      limit,
 	}
+	cityID := 0
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			cityID = claims.CityID
+		}
+	}
 
-	result, err := h.Service.GetFilteredWorks(r.Context(), filter, userID)
+	result, err := h.Service.GetFilteredWorks(r.Context(), filter, userID, cityID)
 	if err != nil {
 		http.Error(w, "Failed to get services", http.StatusInternalServerError)
 		return
@@ -236,6 +261,19 @@ func (h *WorkHandler) GetFilteredWorksPost(w http.ResponseWriter, r *http.Reques
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	works, err := h.Service.GetFilteredWorksPost(r.Context(), req)
@@ -505,6 +543,19 @@ func (h *WorkHandler) GetFilteredWorksWithLikes(w http.ResponseWriter, r *http.R
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	works, err := h.Service.GetFilteredWorksWithLikes(r.Context(), req, userID)

--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -67,6 +67,7 @@ type FilterAdRequest struct {
 	AvgRatings     []int   `json:"avg_rating"`
 	Sorting        int     `json:"sorting"` // 1 - by reviews, 2 - price desc, 3 - price asc
 	UserID         int     `json:"user_id,omitempty"`
+	CityID         int     `json:"city_id,omitempty"`
 }
 
 type FilteredAd struct {

--- a/internal/models/rent.go
+++ b/internal/models/rent.go
@@ -69,6 +69,7 @@ type FilterRentRequest struct {
 	AvgRatings     []int   `json:"avg_rating"`
 	Sorting        int     `json:"sorting"` // 1 - by reviews, 2 - price desc, 3 - price asc
 	UserID         int     `json:"user_id,omitempty"`
+	CityID         int     `json:"city_id,omitempty"`
 }
 
 type FilteredRent struct {

--- a/internal/models/rent_ad.go
+++ b/internal/models/rent_ad.go
@@ -69,6 +69,7 @@ type FilterRentAdRequest struct {
 	AvgRatings     []int   `json:"avg_rating"`
 	Sorting        int     `json:"sorting"` // 1 - by reviews, 2 - price desc, 3 - price asc
 	UserID         int     `json:"user_id,omitempty"`
+	CityID         int     `json:"city_id,omitempty"`
 }
 
 type FilteredRentAd struct {

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -68,6 +68,7 @@ type FilterServicesRequest struct {
 	AvgRatings     []int   `json:"avg_rating"`
 	Sorting        int     `json:"sorting"` // 1 - by reviews, 2 - price desc, 3 - price asc
 	UserID         int     `json:"user_id,omitempty"`
+	CityID         int     `json:"city_id,omitempty"`
 }
 
 type FilteredService struct {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -31,6 +31,7 @@ type User struct {
 type Claims struct {
 	UserID uint   `json:"user_id"`
 	Role   string `json:"role"`
+	CityID int    `json:"city_id"`
 	jwt.StandardClaims
 }
 

--- a/internal/models/work.go
+++ b/internal/models/work.go
@@ -74,6 +74,7 @@ type FilterWorkRequest struct {
 	AvgRatings     []int   `json:"avg_rating"`
 	Sorting        int     `json:"sorting"` // 1 - by reviews, 2 - price desc, 3 - price asc
 	UserID         int     `json:"user_id,omitempty"`
+	CityID         int     `json:"city_id,omitempty"`
 }
 
 type FilteredWork struct {

--- a/internal/models/work_ad.go
+++ b/internal/models/work_ad.go
@@ -58,6 +58,7 @@ type WorkAdFilterRequest struct {
 	SortOption    int       `json:"sort"`
 	Page          int       `json:"page"`
 	Limit         int       `json:"limit"`
+	CityID        int       `json:"city_id,omitempty"`
 }
 
 type WorkAdListResponse struct {
@@ -74,6 +75,7 @@ type FilterWorkAdRequest struct {
 	AvgRatings     []int   `json:"avg_rating"`
 	Sorting        int     `json:"sorting"` // 1 - by reviews, 2 - price desc, 3 - price asc
 	UserID         int     `json:"user_id,omitempty"`
+	CityID         int     `json:"city_id,omitempty"`
 }
 
 type FilteredWorkAd struct {

--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -176,7 +176,7 @@ func (r *AdRepository) UpdateStatus(ctx context.Context, id int, status string) 
 	}
 	return nil
 }
-func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Ad, float64, float64, error) {
+func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, cityID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Ad, float64, float64, error) {
 	var (
 		ads        []models.Ad
 		params     []interface{}
@@ -196,6 +196,11 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, categor
 
        `
 	params = append(params, userID)
+
+	if cityID > 0 {
+		conditions = append(conditions, "s.city_id = ?")
+		params = append(params, cityID)
+	}
 
 	// Filters
 	if len(categories) > 0 {
@@ -373,6 +378,11 @@ func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterA
 		args = append(args, req.PriceFrom, req.PriceTo)
 	}
 
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
+	}
+
 	// Category
 	if len(req.CategoryIDs) > 0 {
 		placeholders := strings.Repeat("?,", len(req.CategoryIDs))
@@ -510,6 +520,11 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 	if req.PriceFrom > 0 && req.PriceTo > 0 {
 		query += " AND s.price BETWEEN ? AND ?"
 		args = append(args, req.PriceFrom, req.PriceTo)
+	}
+
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
 	}
 
 	// Category

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -175,7 +175,7 @@ func (r *RentAdRepository) UpdateStatus(ctx context.Context, id int, status stri
 	}
 	return nil
 }
-func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.RentAd, float64, float64, error) {
+func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int, cityID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.RentAd, float64, float64, error) {
 	var (
 		rents      []models.RentAd
 		params     []interface{}
@@ -191,6 +191,11 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 
        `
 	params = append(params, userID)
+
+	if cityID > 0 {
+		conditions = append(conditions, "s.city_id = ?")
+		params = append(params, cityID)
+	}
 
 	// Filters
 	if len(categories) > 0 {
@@ -351,6 +356,11 @@ func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req model
 		args = append(args, req.PriceFrom, req.PriceTo)
 	}
 
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
+	}
+
 	// Category
 	if len(req.CategoryIDs) > 0 {
 		placeholders := strings.Repeat("?,", len(req.CategoryIDs))
@@ -480,6 +490,11 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 	if req.PriceFrom > 0 && req.PriceTo > 0 {
 		query += " AND s.price BETWEEN ? AND ?"
 		args = append(args, req.PriceFrom, req.PriceTo)
+	}
+
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
 	}
 
 	// Category

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -175,7 +175,7 @@ func (r *RentRepository) UpdateStatus(ctx context.Context, id int, status string
 	}
 	return nil
 }
-func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Rent, float64, float64, error) {
+func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, cityID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Rent, float64, float64, error) {
 	var (
 		rents      []models.Rent
 		params     []interface{}
@@ -191,6 +191,11 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ca
 
        `
 	params = append(params, userID)
+
+	if cityID > 0 {
+		conditions = append(conditions, "s.city_id = ?")
+		params = append(params, cityID)
+	}
 
 	// Filters
 	if len(categories) > 0 {
@@ -366,6 +371,11 @@ func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.Fi
 		args = append(args, req.PriceFrom, req.PriceTo)
 	}
 
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
+	}
+
 	// Category
 	if len(req.CategoryIDs) > 0 {
 		placeholders := strings.Repeat("?,", len(req.CategoryIDs))
@@ -509,6 +519,11 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 	if req.PriceFrom > 0 && req.PriceTo > 0 {
 		query += " AND s.price BETWEEN ? AND ?"
 		args = append(args, req.PriceFrom, req.PriceTo)
+	}
+
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
 	}
 
 	// Category

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -168,7 +168,7 @@ func (r *ServiceRepository) UpdateStatus(ctx context.Context, id int, status str
 	}
 	return nil
 }
-func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Service, float64, float64, error) {
+func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID int, cityID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Service, float64, float64, error) {
 	var (
 		services   []models.Service
 		params     []interface{}
@@ -189,6 +189,11 @@ func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID i
 
       `
 	params = append(params, userID)
+
+	if cityID > 0 {
+		conditions = append(conditions, "s.city_id = ?")
+		params = append(params, cityID)
+	}
 
 	// Filters
 	if len(categories) > 0 {
@@ -360,6 +365,11 @@ func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req mod
 		args = append(args, req.PriceFrom, req.PriceTo)
 	}
 
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
+	}
+
 	// Category
 	if len(req.CategoryIDs) > 0 {
 		placeholders := strings.Repeat("?,", len(req.CategoryIDs))
@@ -497,6 +507,11 @@ func (r *ServiceRepository) GetFilteredServicesWithLikes(ctx context.Context, re
 	if req.PriceFrom > 0 && req.PriceTo > 0 {
 		query += " AND s.price BETWEEN ? AND ?"
 		args = append(args, req.PriceFrom, req.PriceTo)
+	}
+
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
 	}
 
 	// Category filter

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -172,7 +172,7 @@ func (r *WorkAdRepository) UpdateStatus(ctx context.Context, id int, status stri
 	}
 	return nil
 }
-func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.WorkAd, float64, float64, error) {
+func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int, cityID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.WorkAd, float64, float64, error) {
 	var (
 		works_ad   []models.WorkAd
 		params     []interface{}
@@ -188,6 +188,11 @@ func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int
 
        `
 	params = append(params, userID)
+
+	if cityID > 0 {
+		conditions = append(conditions, "s.city_id = ?")
+		params = append(params, cityID)
+	}
 
 	// Filters
 	if len(categories) > 0 {
@@ -344,6 +349,11 @@ func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req model
 `
 	args := []interface{}{}
 
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
+	}
+
 	// Price filter (optional)
 	if req.PriceFrom > 0 && req.PriceTo > 0 {
 		query += " AND s.price BETWEEN ? AND ?"
@@ -469,11 +479,16 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
    FROM work_ad s
    JOIN users u ON s.user_id = u.id
    LEFT JOIN work_ad_favorites sf ON sf.work_ad_id = s.id AND sf.user_id = ?
-   LEFT JOIN work_ad_responses sr ON sr.work_ad_id = s.id AND sr.user_id = ?
-   WHERE 1=1
+  LEFT JOIN work_ad_responses sr ON sr.work_ad_id = s.id AND sr.user_id = ?
+  WHERE 1=1
 `
 
 	args := []interface{}{userID, userID}
+
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
+	}
 
 	// Price filter (optional)
 	if req.PriceFrom > 0 && req.PriceTo > 0 {

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -175,7 +175,7 @@ func (r *WorkRepository) UpdateStatus(ctx context.Context, id int, status string
 	}
 	return nil
 }
-func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Work, float64, float64, error) {
+func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, cityID int, categories []int, subcategories []string, priceFrom, priceTo float64, ratings []float64, sortOption, limit, offset int) ([]models.Work, float64, float64, error) {
 	var (
 		works      []models.Work
 		params     []interface{}
@@ -196,6 +196,11 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ca
 
        `
 	params = append(params, userID)
+
+	if cityID > 0 {
+		conditions = append(conditions, "s.city_id = ?")
+		params = append(params, cityID)
+	}
 
 	// Filters
 	if len(categories) > 0 {
@@ -354,6 +359,11 @@ func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.Fi
 `
 	args := []interface{}{}
 
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
+	}
+
 	// Price filter (optional)
 	if req.PriceFrom > 0 && req.PriceTo > 0 {
 		query += " AND s.price BETWEEN ? AND ?"
@@ -484,6 +494,11 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 `
 
 	args := []interface{}{userID, userID}
+
+	if req.CityID > 0 {
+		query += " AND s.city_id = ?"
+		args = append(args, req.CityID)
+	}
 
 	// Price filter (optional)
 	if req.PriceFrom > 0 && req.PriceTo > 0 {

--- a/internal/services/ad_service.go
+++ b/internal/services/ad_service.go
@@ -30,7 +30,7 @@ func (s *AdService) ArchiveAd(ctx context.Context, id int) error {
 	return s.AdRepo.UpdateStatus(ctx, id, "archive")
 }
 
-func (s *AdService) GetFilteredAd(ctx context.Context, filter models.AdFilterRequest, userID int) (models.AdListResponse, error) {
+func (s *AdService) GetFilteredAd(ctx context.Context, filter models.AdFilterRequest, userID int, cityID int) (models.AdListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1
 	}
@@ -42,6 +42,7 @@ func (s *AdService) GetFilteredAd(ctx context.Context, filter models.AdFilterReq
 	ads, minPrice, maxPrice, err := s.AdRepo.GetAdWithFilters(
 		ctx,
 		userID,
+		cityID,
 		filter.Categories,
 		filter.Subcategories,
 		filter.PriceFrom,

--- a/internal/services/rent_ad_service.go
+++ b/internal/services/rent_ad_service.go
@@ -30,7 +30,7 @@ func (s *RentAdService) ArchiveRentAd(ctx context.Context, id int) error {
 	return s.RentAdRepo.UpdateStatus(ctx, id, "archive")
 }
 
-func (s *RentAdService) GetFilteredRentsAd(ctx context.Context, filter models.RentAdFilterRequest, userID int) (models.RentAdListResponse, error) {
+func (s *RentAdService) GetFilteredRentsAd(ctx context.Context, filter models.RentAdFilterRequest, userID int, cityID int) (models.RentAdListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1
 	}
@@ -42,6 +42,7 @@ func (s *RentAdService) GetFilteredRentsAd(ctx context.Context, filter models.Re
 	rents_ad, minPrice, maxPrice, err := s.RentAdRepo.GetRentsAdWithFilters(
 		ctx,
 		userID,
+		cityID,
 		filter.Categories,
 		filter.Subcategories,
 		filter.PriceFrom,

--- a/internal/services/rent_service.go
+++ b/internal/services/rent_service.go
@@ -53,7 +53,7 @@ func (s *RentService) ArchiveRent(ctx context.Context, id int) error {
 	return s.RentRepo.UpdateStatus(ctx, id, "archive")
 }
 
-func (s *RentService) GetFilteredRents(ctx context.Context, filter models.RentFilterRequest, userID int) (models.RentListResponse, error) {
+func (s *RentService) GetFilteredRents(ctx context.Context, filter models.RentFilterRequest, userID int, cityID int) (models.RentListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1
 	}
@@ -65,6 +65,7 @@ func (s *RentService) GetFilteredRents(ctx context.Context, filter models.RentFi
 	rents, minPrice, maxPrice, err := s.RentRepo.GetRentsWithFilters(
 		ctx,
 		userID,
+		cityID,
 		filter.Categories,
 		filter.Subcategories,
 		filter.PriceFrom,

--- a/internal/services/service_service.go
+++ b/internal/services/service_service.go
@@ -53,7 +53,7 @@ func (s *ServiceService) ArchiveService(ctx context.Context, id int) error {
 	return s.ServiceRepo.UpdateStatus(ctx, id, "archive")
 }
 
-func (s *ServiceService) GetFilteredServices(ctx context.Context, filter models.ServiceFilterRequest, userID int) (models.ServiceListResponse, error) {
+func (s *ServiceService) GetFilteredServices(ctx context.Context, filter models.ServiceFilterRequest, userID int, cityID int) (models.ServiceListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1
 	}
@@ -65,6 +65,7 @@ func (s *ServiceService) GetFilteredServices(ctx context.Context, filter models.
 	services, minPrice, maxPrice, err := s.ServiceRepo.GetServicesWithFilters(
 		ctx,
 		userID,
+		cityID,
 		filter.Categories,
 		filter.Subcategories,
 		filter.PriceFrom,

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -29,6 +29,7 @@ type tokenClaims struct {
 	jwt.StandardClaims
 	UserID int    `json:"user_id"`
 	Role   string `json:"role"`
+	CityID int    `json:"city_id"`
 }
 type UserService struct {
 	UserRepo     *repositories.UserRepository
@@ -161,6 +162,11 @@ func (s *UserService) SignIn(ctx context.Context, name, phone, email, password s
 		return models.Tokens{}, errors.New("invalid password")
 	}
 
+	cityID := 0
+	if user.CityID != nil {
+		cityID = *user.CityID
+	}
+
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &tokenClaims{
 		StandardClaims: jwt.StandardClaims{
 			ExpiresAt: time.Now().Add(tokenTTL).Unix(),
@@ -168,6 +174,7 @@ func (s *UserService) SignIn(ctx context.Context, name, phone, email, password s
 		},
 		UserID: user.ID,
 		Role:   user.Role,
+		CityID: cityID,
 	})
 
 	accessToken, err := token.SignedString([]byte(signingKey))

--- a/internal/services/work_ad_service.go
+++ b/internal/services/work_ad_service.go
@@ -30,7 +30,7 @@ func (s *WorkAdService) ArchiveWorkAd(ctx context.Context, id int) error {
 	return s.WorkAdRepo.UpdateStatus(ctx, id, "archive")
 }
 
-func (s *WorkAdService) GetFilteredWorksAd(ctx context.Context, filter models.WorkAdFilterRequest, userID int) (models.WorkAdListResponse, error) {
+func (s *WorkAdService) GetFilteredWorksAd(ctx context.Context, filter models.WorkAdFilterRequest, userID int, cityID int) (models.WorkAdListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1
 	}
@@ -42,6 +42,7 @@ func (s *WorkAdService) GetFilteredWorksAd(ctx context.Context, filter models.Wo
 	worksad, minPrice, maxPrice, err := s.WorkAdRepo.GetWorksAdWithFilters(
 		ctx,
 		userID,
+		cityID,
 		filter.Categories,
 		filter.Subcategories,
 		filter.PriceFrom,

--- a/internal/services/work_service.go
+++ b/internal/services/work_service.go
@@ -53,7 +53,7 @@ func (s *WorkService) ArchiveWork(ctx context.Context, id int) error {
 	return s.WorkRepo.UpdateStatus(ctx, id, "archive")
 }
 
-func (s *WorkService) GetFilteredWorks(ctx context.Context, filter models.WorkFilterRequest, userID int) (models.WorkListResponse, error) {
+func (s *WorkService) GetFilteredWorks(ctx context.Context, filter models.WorkFilterRequest, userID int, cityID int) (models.WorkListResponse, error) {
 	if filter.Page < 1 {
 		filter.Page = 1
 	}
@@ -65,6 +65,7 @@ func (s *WorkService) GetFilteredWorks(ctx context.Context, filter models.WorkFi
 	works, minPrice, maxPrice, err := s.WorkRepo.GetWorksWithFilters(
 		ctx,
 		userID,
+		cityID,
 		filter.Categories,
 		filter.Subcategories,
 		filter.PriceFrom,


### PR DESCRIPTION
## Summary
- add CityID to filter requests for services, ads, rents, and rent ads
- propagate CityID from handlers through services to repositories for city-scoped listings
- filter queries by `city_id` to show content from the user's city

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b2eb1c79a8832490c192ee2d756816