### PR TITLE
Handle missing service confirmation

### DIFF
--- a/internal/handlers/service_confirmation_handler.go
+++ b/internal/handlers/service_confirmation_handler.go
@@ -2,8 +2,10 @@ package handlers
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
+	"naimuBack/internal/repositories"
 	"naimuBack/internal/services"
 )
 
@@ -41,6 +43,10 @@ func (h *ServiceConfirmationHandler) CancelService(w http.ResponseWriter, r *htt
 		return
 	}
 	if err := h.Service.CancelService(r.Context(), req.ServiceID, userID); err != nil {
+		if errors.Is(err, repositories.ErrServiceConfirmationNotFound) {
+			http.Error(w, "Service confirmation not found", http.StatusNotFound)
+			return
+		}
 		http.Error(w, "Could not cancel service", http.StatusInternalServerError)
 		return
 	}

--- a/internal/repositories/service_confirmation_repository.go
+++ b/internal/repositories/service_confirmation_repository.go
@@ -3,8 +3,13 @@ package repositories
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"naimuBack/internal/models"
 	"time"
+)
+
+var (
+	ErrServiceConfirmationNotFound = errors.New("service confirmation not found")
 )
 
 type ServiceConfirmationRepository struct {
@@ -63,6 +68,9 @@ func (r *ServiceConfirmationRepository) Cancel(ctx context.Context, serviceID, u
 
 	var clientID, performerID int
 	if err := tx.QueryRowContext(ctx, `SELECT client_id, performer_id FROM service_confirmations WHERE service_id = ?`, serviceID).Scan(&clientID, &performerID); err != nil {
+		if err == sql.ErrNoRows {
+			return ErrServiceConfirmationNotFound
+		}
 		return err
 	}
 	if userID == clientID {


### PR DESCRIPTION
## Summary
- return a specific error when cancelling a non-existent service confirmation
- respond with 404 for missing service confirmations in cancel handler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68b7f27da2808324aa22f9b95769fd8b