### PR TITLE
Prevent duplicate chats

### DIFF
--- a/cmd/websocket.go
+++ b/cmd/websocket.go
@@ -229,10 +229,11 @@ func writeClose(conn *websocket.Conn, code int, reason string) error {
 func getOrCreateChat(ctx context.Context, db *sql.DB, user1ID, user2ID int) (int, error) {
 	var chatID int
 	err := db.QueryRowContext(ctx, `
-		SELECT id FROM chats
-		WHERE (user1_id = ? AND user2_id = ?) OR (user1_id = ? AND user2_id = ?)
-		LIMIT 1
-	`, user1ID, user2ID, user2ID, user1ID).Scan(&chatID)
+               SELECT id FROM chats
+               WHERE (user1_id = ? AND user2_id = ?) OR (user1_id = ? AND user2_id = ?)
+               ORDER BY id ASC
+               LIMIT 1
+       `, user1ID, user2ID, user2ID, user1ID).Scan(&chatID)
 	if err == nil {
 		return chatID, nil
 	}

--- a/internal/repositories/chat_repository.go
+++ b/internal/repositories/chat_repository.go
@@ -11,8 +11,20 @@ type ChatRepository struct {
 }
 
 func (r *ChatRepository) CreateChat(ctx context.Context, chat models.Chat) (int, error) {
-	query := `INSERT INTO chats (user1_id, user2_id) VALUES (?, ?)`
-	result, err := r.Db.ExecContext(ctx, query, chat.User1ID, chat.User2ID)
+	// First, try to find existing chat between users
+	var existingID int
+	checkQuery := `SELECT id FROM chats WHERE (user1_id = ? AND user2_id = ?) OR (user1_id = ? AND user2_id = ?) ORDER BY id ASC LIMIT 1`
+	err := r.Db.QueryRowContext(ctx, checkQuery, chat.User1ID, chat.User2ID, chat.User2ID, chat.User1ID).Scan(&existingID)
+	if err == nil {
+		return existingID, nil
+	}
+	if err != sql.ErrNoRows {
+		return 0, err
+	}
+
+	// Chat doesn't exist, create new one
+	insertQuery := `INSERT INTO chats (user1_id, user2_id) VALUES (?, ?)`
+	result, err := r.Db.ExecContext(ctx, insertQuery, chat.User1ID, chat.User2ID)
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
## Summary
- Avoid creating multiple chat rows for same users by returning existing chat if present
- Stabilize websocket chat lookup by ordering results

## Testing
- `go test ./...` *(fails: command hung without output)*

------
https://chatgpt.com/codex/tasks/task_e_68b890f21da08324a634cfeec269172a