### PR TITLE
feat: add websocket location tracking

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -42,6 +42,7 @@ type application struct {
 	cityHandler                handlers.CityHandler
 	cityRepo                   repositories.CityRepository
 	wsManager                  *WebSocketManager
+	locationManager            *LocationManager
 	chatHandler                *handlers.ChatHandler
 	messageHandler             *handlers.MessageHandler
 	db                         *sql.DB

--- a/cmd/location_ws.go
+++ b/cmd/location_ws.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"naimuBack/internal/models"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// LocationUpdate represents user's location data.
+type LocationUpdate struct {
+	UserID    int     `json:"user_id"`
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+// LocationManager manages websocket connections for location sharing.
+type LocationManager struct {
+	clients    map[int]*websocket.Conn
+	register   chan Client
+	unregister chan unreg
+	broadcast  chan LocationUpdate
+}
+
+// NewLocationManager creates a new LocationManager instance.
+func NewLocationManager() *LocationManager {
+	return &LocationManager{
+		clients:    make(map[int]*websocket.Conn),
+		register:   make(chan Client),
+		unregister: make(chan unreg),
+		broadcast:  make(chan LocationUpdate),
+	}
+}
+
+// Run starts the manager loop.
+func (lm *LocationManager) Run() {
+	for {
+		select {
+		case client := <-lm.register:
+			if old, ok := lm.clients[client.ID]; ok && old != nil && old != client.Socket {
+				_ = old.Close()
+			}
+			lm.clients[client.ID] = client.Socket
+		case u := <-lm.unregister:
+			if cur, ok := lm.clients[u.userID]; ok && cur == u.conn {
+				_ = cur.Close()
+				delete(lm.clients, u.userID)
+			}
+		case loc := <-lm.broadcast:
+			for id, conn := range lm.clients {
+				_ = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+				if err := conn.WriteJSON(loc); err != nil {
+					_ = conn.Close()
+					delete(lm.clients, id)
+				}
+			}
+		}
+	}
+}
+
+// LocationWebSocketHandler handles websocket connections for location updates.
+func (app *application) LocationWebSocketHandler(w http.ResponseWriter, r *http.Request) {
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Println("Location WS upgrade error:", err)
+		return
+	}
+
+	conn.SetReadLimit(readLimit)
+	conn.SetReadDeadline(time.Now().Add(firstHelloDeadline))
+	conn.SetPongHandler(func(string) error {
+		conn.SetReadDeadline(time.Now().Add(readDeadline))
+		return nil
+	})
+
+	var hello struct {
+		UserID int `json:"userId"`
+	}
+	if err := conn.ReadJSON(&hello); err != nil || hello.UserID == 0 {
+		log.Println("invalid hello payload for location:", err)
+		_ = writeClose(conn, websocket.ClosePolicyViolation, "hello required")
+		_ = conn.Close()
+		return
+	}
+	conn.SetReadDeadline(time.Now().Add(readDeadline))
+
+	client := Client{ID: hello.UserID, Socket: conn}
+	app.locationManager.register <- client
+
+	go pingLoopLocation(app.locationManager, conn, hello.UserID)
+	go app.handleLocationMessages(conn, hello.UserID)
+}
+
+func pingLoopLocation(lm *LocationManager, conn *websocket.Conn, uid int) {
+	t := time.NewTicker(pingInterval)
+	defer t.Stop()
+	for range t.C {
+		_ = conn.SetWriteDeadline(time.Now().Add(writeDeadline))
+		if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+			_ = writeClose(conn, websocket.CloseGoingAway, "ping error")
+			lm.unregister <- unreg{userID: uid, conn: conn}
+			return
+		}
+	}
+}
+
+func (app *application) handleLocationMessages(conn *websocket.Conn, userID int) {
+	defer func() {
+		app.locationManager.unregister <- unreg{userID: userID, conn: conn}
+		_ = conn.Close()
+	}()
+
+	for {
+		var msg struct {
+			Latitude  float64 `json:"latitude"`
+			Longitude float64 `json:"longitude"`
+		}
+		if err := conn.ReadJSON(&msg); err != nil {
+			log.Println("location read error:", err)
+			_ = writeClose(conn, websocket.CloseNormalClosure, "read error")
+			return
+		}
+
+		latStr := fmt.Sprintf("%f", msg.Latitude)
+		lonStr := fmt.Sprintf("%f", msg.Longitude)
+		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		_, err := app.userRepo.UpdateUser(ctx, models.User{ID: userID, Latitude: &latStr, Longitude: &lonStr})
+		cancel()
+		if err != nil {
+			log.Println("update location error:", err)
+			continue
+		}
+
+		app.locationManager.broadcast <- LocationUpdate{UserID: userID, Latitude: msg.Latitude, Longitude: msg.Longitude}
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -41,7 +41,9 @@ func main() {
 	app := initializeApp(db, errorLog, infoLog)
 
 	app.wsManager = NewWebSocketManager()
+	app.locationManager = NewLocationManager()
 	go app.wsManager.Run(db)
+	go app.locationManager.Run()
 
 	fs := http.FileServer(http.Dir("./uploads"))
 	http.Handle("/static/", http.StripPrefix("/static/", fs))

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -145,6 +145,7 @@ func (app *application) routes() http.Handler {
 
 	// Chat
 	mux.Get("/ws", standardMiddleware.ThenFunc(app.WebSocketHandler))
+	mux.Get("/ws/location", standardMiddleware.ThenFunc(app.LocationWebSocketHandler))
 
 	mux.Post("/api/chats", authMiddleware.ThenFunc(app.chatHandler.CreateChat))
 	mux.Get("/api/chats/:id", authMiddleware.ThenFunc(app.chatHandler.GetChatByID))


### PR DESCRIPTION
## Summary
- add LocationManager for websocket-based live location updates
- expose `/ws/location` endpoint to share performer positions

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c139463c4483248c813c433da3f50b