### PR TITLE
Fix websocket route middleware

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -14,6 +14,7 @@ import (
 	services "naimuBack/internal/services"
 	_ "naimuBack/utils"
 	"net/http"
+	"strings"
 )
 
 type application struct {
@@ -454,6 +455,10 @@ func openDB(dsn string) (*sql.DB, error) {
 
 func addSecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/ws") {
+			next.ServeHTTP(w, r)
+			return
+		}
 		w.Header().Set("Cross-Origin-Opener-Policy", "same-origin")
 		w.Header().Set("Cross-Origin-Embedder-Policy", "require-corp")
 		w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -19,6 +19,8 @@ func (app *application) routes() http.Handler {
 	authMiddleware := standardMiddleware.Append(app.JWTMiddlewareWithRole("user"))
 	adminAuthMiddleware := standardMiddleware.Append(app.JWTMiddlewareWithRole("admin"))
 
+	wsMiddleware := alice.New(app.recoverPanic, app.logRequest)
+
 	mux := pat.New()
 
 	// mux.Get("/swagger/", httpSwagger.WrapHandler)
@@ -144,8 +146,8 @@ func (app *application) routes() http.Handler {
 	mux.Del("/city/:id", authMiddleware.ThenFunc(app.cityHandler.DeleteCity))
 
 	// Chat
-	mux.Get("/ws", standardMiddleware.ThenFunc(app.WebSocketHandler))
-	mux.Get("/ws/location", standardMiddleware.ThenFunc(app.LocationWebSocketHandler))
+	mux.Get("/ws", wsMiddleware.ThenFunc(app.WebSocketHandler))
+	mux.Get("/ws/location", wsMiddleware.ThenFunc(app.LocationWebSocketHandler))
 
 	mux.Post("/api/chats", authMiddleware.ThenFunc(app.chatHandler.CreateChat))
 	mux.Get("/api/chats/:id", authMiddleware.ThenFunc(app.chatHandler.GetChatByID))


### PR DESCRIPTION
## Summary
- refine websocket routes with dedicated middleware
- ensure location websocket upgrades correctly
- bypass security headers for websocket endpoints to avoid 400 errors

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c13e261fb48324a12cc5996294a4c8