### PR TITLE
feat: allow email verification code

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -36,6 +36,7 @@ func (app *application) routes() http.Handler {
 	mux.Post("/user/sign_in", standardMiddleware.ThenFunc(app.userHandler.SignIn))             //РАБОТАЕТ
 	mux.Post("/user/change_number", standardMiddleware.ThenFunc(app.userHandler.ChangeNumber)) //РАБОТАЕТ
 	mux.Post("/user/change_email", standardMiddleware.ThenFunc(app.userHandler.ChangeEmail))   //РАБОТАЕТ
+	mux.Post("/user/send_email_code", standardMiddleware.ThenFunc(app.userHandler.SendCodeToEmail))
 	mux.Put("/user/:id/city", authMiddleware.ThenFunc(app.userHandler.ChangeCityForUser))
 	mux.Get("/docs/:filename", authMiddleware.ThenFunc(app.userHandler.ServeProofDocument))
 	mux.Post("/user/:id/avatar", authMiddleware.ThenFunc(app.userHandler.UploadAvatar))


### PR DESCRIPTION
## Summary
- send verification codes via SMTP when SMS fails and replace code in storage
- expose endpoint to request email verification code

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c1cc2f86448324bb6ca7bc24bebd36