### PR TITLE
Return status for user order history

### DIFF
--- a/internal/models/user_items.go
+++ b/internal/models/user_items.go
@@ -9,5 +9,6 @@ type UserItem struct {
 	Price       float64   `json:"price"`
 	Description string    `json:"description"`
 	CreatedAt   time.Time `json:"created_at"`
+	Status      string    `json:"status"`
 	Type        string    `json:"type"`
 }

--- a/internal/repositories/user_items_repository.go
+++ b/internal/repositories/user_items_repository.go
@@ -15,11 +15,11 @@ type UserItemsRepository struct {
 // GetServiceWorkRentByUserID returns service, work and rent items owned by the user ordered by creation time.
 func (r *UserItemsRepository) GetServiceWorkRentByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
 	query := `
-    SELECT id, name, price, description, created_at, 'service' AS type FROM service WHERE user_id = ?
+    SELECT id, name, price, description, created_at, status, 'service' AS type FROM service WHERE user_id = ?
     UNION ALL
-    SELECT id, name, price, description, created_at, 'work' AS type FROM work WHERE user_id = ?
+    SELECT id, name, price, description, created_at, status, 'work' AS type FROM work WHERE user_id = ?
     UNION ALL
-    SELECT id, name, price, description, created_at, 'rent' AS type FROM rent WHERE user_id = ?
+    SELECT id, name, price, description, created_at, status, 'rent' AS type FROM rent WHERE user_id = ?
     ORDER BY created_at DESC`
 	rows, err := r.DB.QueryContext(ctx, query, userID, userID, userID)
 	if err != nil {
@@ -30,7 +30,7 @@ func (r *UserItemsRepository) GetServiceWorkRentByUserID(ctx context.Context, us
 	var items []models.UserItem
 	for rows.Next() {
 		var item models.UserItem
-		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Type); err != nil {
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Status, &item.Type); err != nil {
 			return nil, err
 		}
 		items = append(items, item)
@@ -41,11 +41,11 @@ func (r *UserItemsRepository) GetServiceWorkRentByUserID(ctx context.Context, us
 // GetAdWorkAdRentAdByUserID returns ad, work_ad and rent_ad items owned by the user ordered by creation time.
 func (r *UserItemsRepository) GetAdWorkAdRentAdByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
 	query := `
-    SELECT id, name, price, description, created_at, 'ad' AS type FROM ad WHERE user_id = ?
+    SELECT id, name, price, description, created_at, status, 'ad' AS type FROM ad WHERE user_id = ?
     UNION ALL
-    SELECT id, name, price, description, created_at, 'work_ad' AS type FROM work_ad WHERE user_id = ?
+    SELECT id, name, price, description, created_at, status, 'work_ad' AS type FROM work_ad WHERE user_id = ?
     UNION ALL
-    SELECT id, name, price, description, created_at, 'rent_ad' AS type FROM rent_ad WHERE user_id = ?
+    SELECT id, name, price, description, created_at, status, 'rent_ad' AS type FROM rent_ad WHERE user_id = ?
     ORDER BY created_at DESC`
 	rows, err := r.DB.QueryContext(ctx, query, userID, userID, userID)
 	if err != nil {
@@ -56,7 +56,7 @@ func (r *UserItemsRepository) GetAdWorkAdRentAdByUserID(ctx context.Context, use
 	var items []models.UserItem
 	for rows.Next() {
 		var item models.UserItem
-		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Type); err != nil {
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Status, &item.Type); err != nil {
 			return nil, err
 		}
 		items = append(items, item)
@@ -67,17 +67,17 @@ func (r *UserItemsRepository) GetAdWorkAdRentAdByUserID(ctx context.Context, use
 // GetOrderHistoryByUserID returns completed service, work, rent, ad, work_ad and rent_ad items for the user ordered by creation time.
 func (r *UserItemsRepository) GetOrderHistoryByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
 	query := `
-    SELECT id, name, price, description, created_at, 'service' AS type FROM service WHERE user_id = ? AND status = 'done'
+    SELECT id, name, price, description, created_at, status, 'service' AS type FROM service WHERE user_id = ? AND status = 'done'
     UNION ALL
-    SELECT id, name, price, description, created_at, 'work' AS type FROM work WHERE user_id = ? AND status = 'done'
+    SELECT id, name, price, description, created_at, status, 'work' AS type FROM work WHERE user_id = ? AND status = 'done'
     UNION ALL
-    SELECT id, name, price, description, created_at, 'rent' AS type FROM rent WHERE user_id = ? AND status = 'done'
+    SELECT id, name, price, description, created_at, status, 'rent' AS type FROM rent WHERE user_id = ? AND status = 'done'
     UNION ALL
-    SELECT id, name, price, description, created_at, 'ad' AS type FROM ad WHERE user_id = ? AND status = 'done'
+    SELECT id, name, price, description, created_at, status, 'ad' AS type FROM ad WHERE user_id = ? AND status = 'done'
     UNION ALL
-    SELECT id, name, price, description, created_at, 'work_ad' AS type FROM work_ad WHERE user_id = ? AND status = 'done'
+    SELECT id, name, price, description, created_at, status, 'work_ad' AS type FROM work_ad WHERE user_id = ? AND status = 'done'
     UNION ALL
-    SELECT id, name, price, description, created_at, 'rent_ad' AS type FROM rent_ad WHERE user_id = ? AND status = 'done'
+    SELECT id, name, price, description, created_at, status, 'rent_ad' AS type FROM rent_ad WHERE user_id = ? AND status = 'done'
     ORDER BY created_at DESC`
 	rows, err := r.DB.QueryContext(ctx, query, userID, userID, userID, userID, userID, userID)
 	if err != nil {
@@ -88,7 +88,7 @@ func (r *UserItemsRepository) GetOrderHistoryByUserID(ctx context.Context, userI
 	var items []models.UserItem
 	for rows.Next() {
 		var item models.UserItem
-		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Type); err != nil {
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Status, &item.Type); err != nil {
 			return nil, err
 		}
 		items = append(items, item)
@@ -99,32 +99,32 @@ func (r *UserItemsRepository) GetOrderHistoryByUserID(ctx context.Context, userI
 // GetActiveOrdersByUserID returns all orders with status active, pending, or done where the user is the performer.
 func (r *UserItemsRepository) GetActiveOrdersByUserID(ctx context.Context, userID int) ([]models.UserItem, error) {
 	query := `
-    SELECT s.id, s.name, s.price, s.description, s.created_at, 'service' AS type
+    SELECT s.id, s.name, s.price, s.description, s.created_at, s.status, 'service' AS type
     FROM service_confirmations sc
     JOIN service s ON s.id = sc.service_id
     WHERE sc.performer_id = ? AND sc.confirmed = true AND s.status IN ('active', 'pending', 'done')
     UNION ALL
-    SELECT w.id, w.name, w.price, w.description, w.created_at, 'work' AS type
+    SELECT w.id, w.name, w.price, w.description, w.created_at, w.status, 'work' AS type
     FROM work_confirmations wc
     JOIN work w ON w.id = wc.work_id
     WHERE wc.performer_id = ? AND wc.confirmed = true AND w.status IN ('active', 'pending', 'done')
     UNION ALL
-    SELECT r.id, r.name, r.price, r.description, r.created_at, 'rent' AS type
+    SELECT r.id, r.name, r.price, r.description, r.created_at, r.status, 'rent' AS type
     FROM rent_confirmations rc
     JOIN rent r ON r.id = rc.rent_id
     WHERE rc.performer_id = ? AND rc.confirmed = true AND r.status IN ('active', 'pending', 'done')
     UNION ALL
-    SELECT a.id, a.name, a.price, a.description, a.created_at, 'ad' AS type
+    SELECT a.id, a.name, a.price, a.description, a.created_at, a.status, 'ad' AS type
     FROM ad_confirmations ac
     JOIN ad a ON a.id = ac.ad_id
     WHERE ac.performer_id = ? AND ac.confirmed = true AND a.status IN ('active', 'pending', 'done')
     UNION ALL
-    SELECT wa.id, wa.name, wa.price, wa.description, wa.created_at, 'work_ad' AS type
+    SELECT wa.id, wa.name, wa.price, wa.description, wa.created_at, wa.status, 'work_ad' AS type
     FROM work_ad_confirmations wac
     JOIN work_ad wa ON wa.id = wac.work_ad_id
     WHERE wac.performer_id = ? AND wac.confirmed = true AND wa.status IN ('active', 'pending', 'done')
     UNION ALL
-    SELECT ra.id, ra.name, ra.price, ra.description, ra.created_at, 'rent_ad' AS type
+    SELECT ra.id, ra.name, ra.price, ra.description, ra.created_at, ra.status, 'rent_ad' AS type
     FROM rent_ad_confirmations rac
     JOIN rent_ad ra ON ra.id = rac.rent_ad_id
     WHERE rac.performer_id = ? AND rac.confirmed = true AND ra.status IN ('active', 'pending', 'done')
@@ -139,7 +139,7 @@ func (r *UserItemsRepository) GetActiveOrdersByUserID(ctx context.Context, userI
 	var items []models.UserItem
 	for rows.Next() {
 		var item models.UserItem
-		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Type); err != nil {
+		if err := rows.Scan(&item.ID, &item.Name, &item.Price, &item.Description, &item.CreatedAt, &item.Status, &item.Type); err != nil {
 			return nil, err
 		}
 		items = append(items, item)


### PR DESCRIPTION
## Summary
- extend `UserItem` to include `status`
- propagate status through user item queries so `/user/orders/:id` includes order status

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c28fcac4388324ad4e26ffc367ecbd