### PR TITLE
Allow archive endpoints to restore entities

### DIFF
--- a/internal/handlers/ad_handler.go
+++ b/internal/handlers/ad_handler.go
@@ -89,13 +89,14 @@ func (h *AdHandler) DeleteAd(w http.ResponseWriter, r *http.Request) {
 
 func (h *AdHandler) ArchiveAd(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		AdID int `json:"ad_id"`
+		AdID    int `json:"ad_id"`
+		Archive int `json:"archive"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if err := h.Service.ArchiveAd(r.Context(), req.AdID); err != nil {
+	if err := h.Service.ArchiveAd(r.Context(), req.AdID, req.Archive == 1); err != nil {
 		http.Error(w, "Failed to archive ad", http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/rent_ad_handler.go
+++ b/internal/handlers/rent_ad_handler.go
@@ -90,12 +90,13 @@ func (h *RentAdHandler) DeleteRentAd(w http.ResponseWriter, r *http.Request) {
 func (h *RentAdHandler) ArchiveRentAd(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		RentAdID int `json:"rent_ad_id"`
+		Archive  int `json:"archive"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if err := h.Service.ArchiveRentAd(r.Context(), req.RentAdID); err != nil {
+	if err := h.Service.ArchiveRentAd(r.Context(), req.RentAdID, req.Archive == 1); err != nil {
 		http.Error(w, "Failed to archive rent ad", http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/rent_handler.go
+++ b/internal/handlers/rent_handler.go
@@ -89,13 +89,14 @@ func (h *RentHandler) DeleteRent(w http.ResponseWriter, r *http.Request) {
 
 func (h *RentHandler) ArchiveRent(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		RentID int `json:"rent_id"`
+		RentID  int `json:"rent_id"`
+		Archive int `json:"archive"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if err := h.Service.ArchiveRent(r.Context(), req.RentID); err != nil {
+	if err := h.Service.ArchiveRent(r.Context(), req.RentID, req.Archive == 1); err != nil {
 		http.Error(w, "Failed to archive rent", http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -90,12 +90,13 @@ func (h *ServiceHandler) DeleteService(w http.ResponseWriter, r *http.Request) {
 func (h *ServiceHandler) ArchiveService(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		ServiceID int `json:"service_id"`
+		Archive   int `json:"archive"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if err := h.Service.ArchiveService(r.Context(), req.ServiceID); err != nil {
+	if err := h.Service.ArchiveService(r.Context(), req.ServiceID, req.Archive == 1); err != nil {
 		http.Error(w, "Failed to archive service", http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/work_ad_handler.go
+++ b/internal/handlers/work_ad_handler.go
@@ -90,12 +90,13 @@ func (h *WorkAdHandler) DeleteWorkAd(w http.ResponseWriter, r *http.Request) {
 func (h *WorkAdHandler) ArchiveWorkAd(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		WorkAdID int `json:"work_ad_id"`
+		Archive  int `json:"archive"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if err := h.Service.ArchiveWorkAd(r.Context(), req.WorkAdID); err != nil {
+	if err := h.Service.ArchiveWorkAd(r.Context(), req.WorkAdID, req.Archive == 1); err != nil {
 		http.Error(w, "Failed to archive work ad", http.StatusInternalServerError)
 		return
 	}

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -89,13 +89,14 @@ func (h *WorkHandler) DeleteWork(w http.ResponseWriter, r *http.Request) {
 
 func (h *WorkHandler) ArchiveWork(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		WorkID int `json:"work_id"`
+		WorkID  int `json:"work_id"`
+		Archive int `json:"archive"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid JSON", http.StatusBadRequest)
 		return
 	}
-	if err := h.Service.ArchiveWork(r.Context(), req.WorkID); err != nil {
+	if err := h.Service.ArchiveWork(r.Context(), req.WorkID, req.Archive == 1); err != nil {
 		http.Error(w, "Failed to archive work", http.StatusInternalServerError)
 		return
 	}

--- a/internal/services/ad_service.go
+++ b/internal/services/ad_service.go
@@ -26,8 +26,12 @@ func (s *AdService) DeleteAd(ctx context.Context, id int) error {
 	return s.AdRepo.DeleteAd(ctx, id)
 }
 
-func (s *AdService) ArchiveAd(ctx context.Context, id int) error {
-	return s.AdRepo.UpdateStatus(ctx, id, "archive")
+func (s *AdService) ArchiveAd(ctx context.Context, id int, archive bool) error {
+	status := "archive"
+	if !archive {
+		status = "active"
+	}
+	return s.AdRepo.UpdateStatus(ctx, id, status)
 }
 
 func (s *AdService) GetFilteredAd(ctx context.Context, filter models.AdFilterRequest, userID int, cityID int) (models.AdListResponse, error) {

--- a/internal/services/rent_ad_service.go
+++ b/internal/services/rent_ad_service.go
@@ -26,8 +26,12 @@ func (s *RentAdService) DeleteRentAd(ctx context.Context, id int) error {
 	return s.RentAdRepo.DeleteRentAd(ctx, id)
 }
 
-func (s *RentAdService) ArchiveRentAd(ctx context.Context, id int) error {
-	return s.RentAdRepo.UpdateStatus(ctx, id, "archive")
+func (s *RentAdService) ArchiveRentAd(ctx context.Context, id int, archive bool) error {
+	status := "archive"
+	if !archive {
+		status = "active"
+	}
+	return s.RentAdRepo.UpdateStatus(ctx, id, status)
 }
 
 func (s *RentAdService) GetFilteredRentsAd(ctx context.Context, filter models.RentAdFilterRequest, userID int, cityID int) (models.RentAdListResponse, error) {

--- a/internal/services/rent_service.go
+++ b/internal/services/rent_service.go
@@ -49,8 +49,12 @@ func (s *RentService) DeleteRent(ctx context.Context, id int) error {
 	return s.RentRepo.DeleteRent(ctx, id)
 }
 
-func (s *RentService) ArchiveRent(ctx context.Context, id int) error {
-	return s.RentRepo.UpdateStatus(ctx, id, "archive")
+func (s *RentService) ArchiveRent(ctx context.Context, id int, archive bool) error {
+	status := "archive"
+	if !archive {
+		status = "active"
+	}
+	return s.RentRepo.UpdateStatus(ctx, id, status)
 }
 
 func (s *RentService) GetFilteredRents(ctx context.Context, filter models.RentFilterRequest, userID int, cityID int) (models.RentListResponse, error) {

--- a/internal/services/service_service.go
+++ b/internal/services/service_service.go
@@ -49,8 +49,12 @@ func (s *ServiceService) DeleteService(ctx context.Context, id int) error {
 	return s.ServiceRepo.DeleteService(ctx, id)
 }
 
-func (s *ServiceService) ArchiveService(ctx context.Context, id int) error {
-	return s.ServiceRepo.UpdateStatus(ctx, id, "archive")
+func (s *ServiceService) ArchiveService(ctx context.Context, id int, archive bool) error {
+	status := "archive"
+	if !archive {
+		status = "active"
+	}
+	return s.ServiceRepo.UpdateStatus(ctx, id, status)
 }
 
 func (s *ServiceService) GetFilteredServices(ctx context.Context, filter models.ServiceFilterRequest, userID int, cityID int) (models.ServiceListResponse, error) {

--- a/internal/services/work_ad_service.go
+++ b/internal/services/work_ad_service.go
@@ -26,8 +26,12 @@ func (s *WorkAdService) DeleteWorkAd(ctx context.Context, id int) error {
 	return s.WorkAdRepo.DeleteWorkAd(ctx, id)
 }
 
-func (s *WorkAdService) ArchiveWorkAd(ctx context.Context, id int) error {
-	return s.WorkAdRepo.UpdateStatus(ctx, id, "archive")
+func (s *WorkAdService) ArchiveWorkAd(ctx context.Context, id int, archive bool) error {
+	status := "archive"
+	if !archive {
+		status = "active"
+	}
+	return s.WorkAdRepo.UpdateStatus(ctx, id, status)
 }
 
 func (s *WorkAdService) GetFilteredWorksAd(ctx context.Context, filter models.WorkAdFilterRequest, userID int, cityID int) (models.WorkAdListResponse, error) {

--- a/internal/services/work_service.go
+++ b/internal/services/work_service.go
@@ -49,8 +49,12 @@ func (s *WorkService) DeleteWork(ctx context.Context, id int) error {
 	return s.WorkRepo.DeleteWork(ctx, id)
 }
 
-func (s *WorkService) ArchiveWork(ctx context.Context, id int) error {
-	return s.WorkRepo.UpdateStatus(ctx, id, "archive")
+func (s *WorkService) ArchiveWork(ctx context.Context, id int, archive bool) error {
+	status := "archive"
+	if !archive {
+		status = "active"
+	}
+	return s.WorkRepo.UpdateStatus(ctx, id, status)
 }
 
 func (s *WorkService) GetFilteredWorks(ctx context.Context, filter models.WorkFilterRequest, userID int, cityID int) (models.WorkListResponse, error) {


### PR DESCRIPTION
## Summary
- allow Service, Ad, Rent, Work, WorkAd, and RentAd archive endpoints to also restore entities
- new `archive` field in request body toggles between archived and active statuses

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c295b57ef48324aeb875a20e5dfaf1