### PR TITLE
Preserve existing data on partial updates

### DIFF
--- a/internal/handlers/ad_handler.go
+++ b/internal/handlers/ad_handler.go
@@ -411,23 +411,57 @@ func (h *AdHandler) UpdateAd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var service models.Ad
-	service.ID = id
-	service.Name = r.FormValue("name")
-	service.Address = r.FormValue("address")
-	service.Price, _ = strconv.ParseFloat(r.FormValue("price"), 64)
-	service.UserID, _ = strconv.Atoi(r.FormValue("user_id"))
-	service.Description = r.FormValue("description")
-	service.CategoryID, _ = strconv.Atoi(r.FormValue("category_id"))
-	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
-	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
-	service.Top = r.FormValue("top")
-	service.Liked = r.FormValue("liked") == "true"
-	service.Status = r.FormValue("status")
-	now := time.Now()
-	service.UpdatedAt = &now
+	existingService, err := h.Service.GetAdByID(r.Context(), id, 0)
+	if err != nil {
+		http.Error(w, "Service not found", http.StatusNotFound)
+		return
+	}
 
-	// Обработка изображений
+	service := existingService
+
+	if _, ok := r.MultipartForm.Value["name"]; ok {
+		service.Name = r.FormValue("name")
+	}
+	if _, ok := r.MultipartForm.Value["address"]; ok {
+		service.Address = r.FormValue("address")
+	}
+	if v, ok := r.MultipartForm.Value["price"]; ok {
+		service.Price, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if v, ok := r.MultipartForm.Value["user_id"]; ok {
+		service.UserID, _ = strconv.Atoi(v[0])
+	}
+	if _, ok := r.MultipartForm.Value["description"]; ok {
+		service.Description = r.FormValue("description")
+	}
+	if v, ok := r.MultipartForm.Value["category_id"]; ok {
+		service.CategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["subcategory_id"]; ok {
+		service.SubcategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["avg_rating"]; ok {
+		service.AvgRating, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if _, ok := r.MultipartForm.Value["top"]; ok {
+		service.Top = r.FormValue("top")
+	}
+	if _, ok := r.MultipartForm.Value["liked"]; ok {
+		service.Liked = r.FormValue("liked") == "true"
+	}
+	if _, ok := r.MultipartForm.Value["status"]; ok {
+		service.Status = r.FormValue("status")
+	}
+
+	if v, ok := r.MultipartForm.Value["latitude"]; ok {
+		lat := v[0]
+		service.Latitude = &lat
+	}
+	if v, ok := r.MultipartForm.Value["longitude"]; ok {
+		lon := v[0]
+		service.Longitude = &lon
+	}
+
 	saveDir := "cmd/uploads/ad"
 	err = os.MkdirAll(saveDir, 0755)
 	if err != nil {
@@ -435,43 +469,45 @@ func (h *AdHandler) UpdateAd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files := r.MultipartForm.File["images"]
-	var imageInfos []models.ImageAd
+	if files, ok := r.MultipartForm.File["images"]; ok && len(files) > 0 {
+		var imageInfos []models.ImageAd
+		for _, fileHeader := range files {
+			file, err := fileHeader.Open()
+			if err != nil {
+				http.Error(w, "Failed to open image", http.StatusInternalServerError)
+				return
+			}
+			defer file.Close()
 
-	for _, fileHeader := range files {
-		file, err := fileHeader.Open()
-		if err != nil {
-			http.Error(w, "Failed to open image", http.StatusInternalServerError)
-			return
+			timestamp := time.Now().UnixNano()
+			ext := filepath.Ext(fileHeader.Filename)
+			imageName := fmt.Sprintf("ad_image_%d%s", timestamp, ext)
+			savePath := filepath.Join(saveDir, imageName)
+			publicURL := fmt.Sprintf("/images/ad/%s", imageName)
+
+			dst, err := os.Create(savePath)
+			if err != nil {
+				http.Error(w, "Cannot save image", http.StatusInternalServerError)
+				return
+			}
+			defer dst.Close()
+
+			if _, err := io.Copy(dst, file); err != nil {
+				http.Error(w, "Failed to write image", http.StatusInternalServerError)
+				return
+			}
+
+			imageInfos = append(imageInfos, models.ImageAd{
+				Name: fileHeader.Filename,
+				Path: publicURL,
+				Type: fileHeader.Header.Get("Content-Type"),
+			})
 		}
-		defer file.Close()
-
-		timestamp := time.Now().UnixNano()
-		ext := filepath.Ext(fileHeader.Filename)
-		imageName := fmt.Sprintf("ad_image_%d%s", timestamp, ext)
-		savePath := filepath.Join(saveDir, imageName)
-		publicURL := fmt.Sprintf("/images/ad/%s", imageName)
-
-		dst, err := os.Create(savePath)
-		if err != nil {
-			http.Error(w, "Cannot save image", http.StatusInternalServerError)
-			return
-		}
-		defer dst.Close()
-
-		if _, err := io.Copy(dst, file); err != nil {
-			http.Error(w, "Failed to write image", http.StatusInternalServerError)
-			return
-		}
-
-		imageInfos = append(imageInfos, models.ImageAd{
-			Name: fileHeader.Filename,
-			Path: publicURL,
-			Type: fileHeader.Header.Get("Content-Type"),
-		})
+		service.Images = imageInfos
 	}
 
-	service.Images = imageInfos
+	now := time.Now()
+	service.UpdatedAt = &now
 
 	updatedService, err := h.Service.UpdateAd(r.Context(), service)
 	if err != nil {

--- a/internal/handlers/rent_ad_handler.go
+++ b/internal/handlers/rent_ad_handler.go
@@ -415,27 +415,60 @@ func (h *RentAdHandler) UpdateRentAd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var service models.RentAd
-	service.ID = id
-	service.Name = r.FormValue("name")
-	service.Address = r.FormValue("address")
-	service.Price, _ = strconv.ParseFloat(r.FormValue("price"), 64)
-	service.UserID, _ = strconv.Atoi(r.FormValue("user_id"))
-	service.Description = r.FormValue("description")
-	service.CategoryID, _ = strconv.Atoi(r.FormValue("category_id"))
-	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
-	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
-	service.RentType = r.FormValue("rent_type")
-	service.Deposit = r.FormValue("deposit")
-	service.Latitude = r.FormValue("latitude")
-	service.Longitude = r.FormValue("longitude")
-	service.Top = r.FormValue("top")
-	service.Liked = r.FormValue("liked") == "true"
-	service.Status = r.FormValue("status")
-	now := time.Now()
-	service.UpdatedAt = &now
+	existingService, err := h.Service.GetRentAdByID(r.Context(), id, 0)
+	if err != nil {
+		http.Error(w, "Service not found", http.StatusNotFound)
+		return
+	}
 
-	// Обработка изображений
+	service := existingService
+
+	if _, ok := r.MultipartForm.Value["name"]; ok {
+		service.Name = r.FormValue("name")
+	}
+	if _, ok := r.MultipartForm.Value["address"]; ok {
+		service.Address = r.FormValue("address")
+	}
+	if v, ok := r.MultipartForm.Value["price"]; ok {
+		service.Price, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if v, ok := r.MultipartForm.Value["user_id"]; ok {
+		service.UserID, _ = strconv.Atoi(v[0])
+	}
+	if _, ok := r.MultipartForm.Value["description"]; ok {
+		service.Description = r.FormValue("description")
+	}
+	if v, ok := r.MultipartForm.Value["category_id"]; ok {
+		service.CategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["subcategory_id"]; ok {
+		service.SubcategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["avg_rating"]; ok {
+		service.AvgRating, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if _, ok := r.MultipartForm.Value["rent_type"]; ok {
+		service.RentType = r.FormValue("rent_type")
+	}
+	if _, ok := r.MultipartForm.Value["deposit"]; ok {
+		service.Deposit = r.FormValue("deposit")
+	}
+	if _, ok := r.MultipartForm.Value["latitude"]; ok {
+		service.Latitude = r.FormValue("latitude")
+	}
+	if _, ok := r.MultipartForm.Value["longitude"]; ok {
+		service.Longitude = r.FormValue("longitude")
+	}
+	if _, ok := r.MultipartForm.Value["top"]; ok {
+		service.Top = r.FormValue("top")
+	}
+	if _, ok := r.MultipartForm.Value["liked"]; ok {
+		service.Liked = r.FormValue("liked") == "true"
+	}
+	if _, ok := r.MultipartForm.Value["status"]; ok {
+		service.Status = r.FormValue("status")
+	}
+
 	saveDir := "cmd/uploads/rents_ad"
 	err = os.MkdirAll(saveDir, 0755)
 	if err != nil {
@@ -443,43 +476,45 @@ func (h *RentAdHandler) UpdateRentAd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files := r.MultipartForm.File["images"]
-	var imageInfos []models.ImageRentAd
+	if files, ok := r.MultipartForm.File["images"]; ok && len(files) > 0 {
+		var imageInfos []models.ImageRentAd
+		for _, fileHeader := range files {
+			file, err := fileHeader.Open()
+			if err != nil {
+				http.Error(w, "Failed to open image", http.StatusInternalServerError)
+				return
+			}
+			defer file.Close()
 
-	for _, fileHeader := range files {
-		file, err := fileHeader.Open()
-		if err != nil {
-			http.Error(w, "Failed to open image", http.StatusInternalServerError)
-			return
+			timestamp := time.Now().UnixNano()
+			ext := filepath.Ext(fileHeader.Filename)
+			imageName := fmt.Sprintf("rent_ad_image_%d%s", timestamp, ext)
+			savePath := filepath.Join(saveDir, imageName)
+			publicURL := fmt.Sprintf("/images/rents_ad/%s", imageName)
+
+			dst, err := os.Create(savePath)
+			if err != nil {
+				http.Error(w, "Cannot save image", http.StatusInternalServerError)
+				return
+			}
+			defer dst.Close()
+
+			if _, err := io.Copy(dst, file); err != nil {
+				http.Error(w, "Failed to write image", http.StatusInternalServerError)
+				return
+			}
+
+			imageInfos = append(imageInfos, models.ImageRentAd{
+				Name: fileHeader.Filename,
+				Path: publicURL,
+				Type: fileHeader.Header.Get("Content-Type"),
+			})
 		}
-		defer file.Close()
-
-		timestamp := time.Now().UnixNano()
-		ext := filepath.Ext(fileHeader.Filename)
-		imageName := fmt.Sprintf("rent_ad_image_%d%s", timestamp, ext)
-		savePath := filepath.Join(saveDir, imageName)
-		publicURL := fmt.Sprintf("/images/rents_ad/%s", imageName)
-
-		dst, err := os.Create(savePath)
-		if err != nil {
-			http.Error(w, "Cannot save image", http.StatusInternalServerError)
-			return
-		}
-		defer dst.Close()
-
-		if _, err := io.Copy(dst, file); err != nil {
-			http.Error(w, "Failed to write image", http.StatusInternalServerError)
-			return
-		}
-
-		imageInfos = append(imageInfos, models.ImageRentAd{
-			Name: fileHeader.Filename,
-			Path: publicURL,
-			Type: fileHeader.Header.Get("Content-Type"),
-		})
+		service.Images = imageInfos
 	}
 
-	service.Images = imageInfos
+	now := time.Now()
+	service.UpdatedAt = &now
 
 	updatedService, err := h.Service.UpdateRentAd(r.Context(), service)
 	if err != nil {

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -417,23 +417,48 @@ func (h *ServiceHandler) UpdateService(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var service models.Service
-	service.ID = id
-	service.Name = r.FormValue("name")
-	service.Address = r.FormValue("address")
-	service.Price, _ = strconv.ParseFloat(r.FormValue("price"), 64)
-	service.UserID, _ = strconv.Atoi(r.FormValue("user_id"))
-	service.Description = r.FormValue("description")
-	service.CategoryID, _ = strconv.Atoi(r.FormValue("category_id"))
-	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
-	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
-	service.Top = r.FormValue("top")
-	service.Liked = r.FormValue("liked") == "true"
-	service.Status = r.FormValue("status")
-	now := time.Now()
-	service.UpdatedAt = &now
+	existingService, err := h.Service.GetServiceByID(r.Context(), id, 0)
+	if err != nil {
+		http.Error(w, "Service not found", http.StatusNotFound)
+		return
+	}
 
-	// Обработка изображений
+	service := existingService
+
+	if _, ok := r.MultipartForm.Value["name"]; ok {
+		service.Name = r.FormValue("name")
+	}
+	if _, ok := r.MultipartForm.Value["address"]; ok {
+		service.Address = r.FormValue("address")
+	}
+	if v, ok := r.MultipartForm.Value["price"]; ok {
+		service.Price, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if v, ok := r.MultipartForm.Value["user_id"]; ok {
+		service.UserID, _ = strconv.Atoi(v[0])
+	}
+	if _, ok := r.MultipartForm.Value["description"]; ok {
+		service.Description = r.FormValue("description")
+	}
+	if v, ok := r.MultipartForm.Value["category_id"]; ok {
+		service.CategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["subcategory_id"]; ok {
+		service.SubcategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["avg_rating"]; ok {
+		service.AvgRating, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if _, ok := r.MultipartForm.Value["top"]; ok {
+		service.Top = r.FormValue("top")
+	}
+	if _, ok := r.MultipartForm.Value["liked"]; ok {
+		service.Liked = r.FormValue("liked") == "true"
+	}
+	if _, ok := r.MultipartForm.Value["status"]; ok {
+		service.Status = r.FormValue("status")
+	}
+
 	saveDir := "cmd/uploads/services"
 	err = os.MkdirAll(saveDir, 0755)
 	if err != nil {
@@ -441,43 +466,45 @@ func (h *ServiceHandler) UpdateService(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files := r.MultipartForm.File["images"]
-	var imageInfos []models.Image
+	if files, ok := r.MultipartForm.File["images"]; ok && len(files) > 0 {
+		var imageInfos []models.Image
+		for _, fileHeader := range files {
+			file, err := fileHeader.Open()
+			if err != nil {
+				http.Error(w, "Failed to open image", http.StatusInternalServerError)
+				return
+			}
+			defer file.Close()
 
-	for _, fileHeader := range files {
-		file, err := fileHeader.Open()
-		if err != nil {
-			http.Error(w, "Failed to open image", http.StatusInternalServerError)
-			return
+			timestamp := time.Now().UnixNano()
+			ext := filepath.Ext(fileHeader.Filename)
+			imageName := fmt.Sprintf("service_image_%d%s", timestamp, ext)
+			savePath := filepath.Join(saveDir, imageName)
+			publicURL := fmt.Sprintf("/images/services/%s", imageName)
+
+			dst, err := os.Create(savePath)
+			if err != nil {
+				http.Error(w, "Cannot save image", http.StatusInternalServerError)
+				return
+			}
+			defer dst.Close()
+
+			if _, err := io.Copy(dst, file); err != nil {
+				http.Error(w, "Failed to write image", http.StatusInternalServerError)
+				return
+			}
+
+			imageInfos = append(imageInfos, models.Image{
+				Name: fileHeader.Filename,
+				Path: publicURL,
+				Type: fileHeader.Header.Get("Content-Type"),
+			})
 		}
-		defer file.Close()
-
-		timestamp := time.Now().UnixNano()
-		ext := filepath.Ext(fileHeader.Filename)
-		imageName := fmt.Sprintf("service_image_%d%s", timestamp, ext)
-		savePath := filepath.Join(saveDir, imageName)
-		publicURL := fmt.Sprintf("/images/services/%s", imageName)
-
-		dst, err := os.Create(savePath)
-		if err != nil {
-			http.Error(w, "Cannot save image", http.StatusInternalServerError)
-			return
-		}
-		defer dst.Close()
-
-		if _, err := io.Copy(dst, file); err != nil {
-			http.Error(w, "Failed to write image", http.StatusInternalServerError)
-			return
-		}
-
-		imageInfos = append(imageInfos, models.Image{
-			Name: fileHeader.Filename,
-			Path: publicURL,
-			Type: fileHeader.Header.Get("Content-Type"),
-		})
+		service.Images = imageInfos
 	}
 
-	service.Images = imageInfos
+	now := time.Now()
+	service.UpdatedAt = &now
 
 	updatedService, err := h.Service.UpdateService(r.Context(), service)
 	if err != nil {

--- a/internal/handlers/work_ad_handler.go
+++ b/internal/handlers/work_ad_handler.go
@@ -444,30 +444,69 @@ func (h *WorkAdHandler) UpdateWorkAd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var service models.WorkAd
-	service.ID = id
-	service.Name = r.FormValue("name")
-	service.Address = r.FormValue("address")
-	service.Price, _ = strconv.ParseFloat(r.FormValue("price"), 64)
-	service.UserID, _ = strconv.Atoi(r.FormValue("user_id"))
-	service.Description = r.FormValue("description")
-	service.CategoryID, _ = strconv.Atoi(r.FormValue("category_id"))
-	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
-	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
-	service.Top = r.FormValue("top")
-	service.Liked = r.FormValue("liked") == "true"
-	service.Status = r.FormValue("status")
-	service.WorkExperience = r.FormValue("work_experience")
-	service.CityID, _ = strconv.Atoi(r.FormValue("city_id"))
-	service.Schedule = r.FormValue("schedule")
-	service.DistanceWork = r.FormValue("distance_work")
-	service.PaymentPeriod = r.FormValue("payment_period")
-	service.Latitude = r.FormValue("latitude")
-	service.Longitude = r.FormValue("longitude")
-	now := time.Now()
-	service.UpdatedAt = &now
+	existingService, err := h.Service.GetWorkAdByID(r.Context(), id, 0)
+	if err != nil {
+		http.Error(w, "Service not found", http.StatusNotFound)
+		return
+	}
 
-	// Обработка изображений
+	service := existingService
+
+	if _, ok := r.MultipartForm.Value["name"]; ok {
+		service.Name = r.FormValue("name")
+	}
+	if _, ok := r.MultipartForm.Value["address"]; ok {
+		service.Address = r.FormValue("address")
+	}
+	if v, ok := r.MultipartForm.Value["price"]; ok {
+		service.Price, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if v, ok := r.MultipartForm.Value["user_id"]; ok {
+		service.UserID, _ = strconv.Atoi(v[0])
+	}
+	if _, ok := r.MultipartForm.Value["description"]; ok {
+		service.Description = r.FormValue("description")
+	}
+	if v, ok := r.MultipartForm.Value["category_id"]; ok {
+		service.CategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["subcategory_id"]; ok {
+		service.SubcategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["avg_rating"]; ok {
+		service.AvgRating, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if _, ok := r.MultipartForm.Value["top"]; ok {
+		service.Top = r.FormValue("top")
+	}
+	if _, ok := r.MultipartForm.Value["liked"]; ok {
+		service.Liked = r.FormValue("liked") == "true"
+	}
+	if _, ok := r.MultipartForm.Value["status"]; ok {
+		service.Status = r.FormValue("status")
+	}
+	if _, ok := r.MultipartForm.Value["work_experience"]; ok {
+		service.WorkExperience = r.FormValue("work_experience")
+	}
+	if v, ok := r.MultipartForm.Value["city_id"]; ok {
+		service.CityID, _ = strconv.Atoi(v[0])
+	}
+	if _, ok := r.MultipartForm.Value["schedule"]; ok {
+		service.Schedule = r.FormValue("schedule")
+	}
+	if _, ok := r.MultipartForm.Value["distance_work"]; ok {
+		service.DistanceWork = r.FormValue("distance_work")
+	}
+	if _, ok := r.MultipartForm.Value["payment_period"]; ok {
+		service.PaymentPeriod = r.FormValue("payment_period")
+	}
+	if _, ok := r.MultipartForm.Value["latitude"]; ok {
+		service.Latitude = r.FormValue("latitude")
+	}
+	if _, ok := r.MultipartForm.Value["longitude"]; ok {
+		service.Longitude = r.FormValue("longitude")
+	}
+
 	saveDir := "cmd/uploads/worksad"
 	err = os.MkdirAll(saveDir, 0755)
 	if err != nil {
@@ -475,43 +514,45 @@ func (h *WorkAdHandler) UpdateWorkAd(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files := r.MultipartForm.File["images"]
-	var imageInfos []models.ImageWorkAd
+	if files, ok := r.MultipartForm.File["images"]; ok && len(files) > 0 {
+		var imageInfos []models.ImageWorkAd
+		for _, fileHeader := range files {
+			file, err := fileHeader.Open()
+			if err != nil {
+				http.Error(w, "Failed to open image", http.StatusInternalServerError)
+				return
+			}
+			defer file.Close()
 
-	for _, fileHeader := range files {
-		file, err := fileHeader.Open()
-		if err != nil {
-			http.Error(w, "Failed to open image", http.StatusInternalServerError)
-			return
+			timestamp := time.Now().UnixNano()
+			ext := filepath.Ext(fileHeader.Filename)
+			imageName := fmt.Sprintf("work_image_%d%s", timestamp, ext)
+			savePath := filepath.Join(saveDir, imageName)
+			publicURL := fmt.Sprintf("/images/works/%s", imageName)
+
+			dst, err := os.Create(savePath)
+			if err != nil {
+				http.Error(w, "Cannot save image", http.StatusInternalServerError)
+				return
+			}
+			defer dst.Close()
+
+			if _, err := io.Copy(dst, file); err != nil {
+				http.Error(w, "Failed to write image", http.StatusInternalServerError)
+				return
+			}
+
+			imageInfos = append(imageInfos, models.ImageWorkAd{
+				Name: fileHeader.Filename,
+				Path: publicURL,
+				Type: fileHeader.Header.Get("Content-Type"),
+			})
 		}
-		defer file.Close()
-
-		timestamp := time.Now().UnixNano()
-		ext := filepath.Ext(fileHeader.Filename)
-		imageName := fmt.Sprintf("work_image_%d%s", timestamp, ext)
-		savePath := filepath.Join(saveDir, imageName)
-		publicURL := fmt.Sprintf("/images/works/%s", imageName)
-
-		dst, err := os.Create(savePath)
-		if err != nil {
-			http.Error(w, "Cannot save image", http.StatusInternalServerError)
-			return
-		}
-		defer dst.Close()
-
-		if _, err := io.Copy(dst, file); err != nil {
-			http.Error(w, "Failed to write image", http.StatusInternalServerError)
-			return
-		}
-
-		imageInfos = append(imageInfos, models.ImageWorkAd{
-			Name: fileHeader.Filename,
-			Path: publicURL,
-			Type: fileHeader.Header.Get("Content-Type"),
-		})
+		service.Images = imageInfos
 	}
 
-	service.Images = imageInfos
+	now := time.Now()
+	service.UpdatedAt = &now
 
 	updatedService, err := h.Service.UpdateWorkAd(r.Context(), service)
 	if err != nil {

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -448,30 +448,69 @@ func (h *WorkHandler) UpdateWork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var service models.Work
-	service.ID = id
-	service.Name = r.FormValue("name")
-	service.Address = r.FormValue("address")
-	service.Price, _ = strconv.ParseFloat(r.FormValue("price"), 64)
-	service.UserID, _ = strconv.Atoi(r.FormValue("user_id"))
-	service.Description = r.FormValue("description")
-	service.CategoryID, _ = strconv.Atoi(r.FormValue("category_id"))
-	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
-	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
-	service.Top = r.FormValue("top")
-	service.Liked = r.FormValue("liked") == "true"
-	service.Status = r.FormValue("status")
-	service.WorkExperience = r.FormValue("work_experience")
-	service.CityID, _ = strconv.Atoi(r.FormValue("city_id"))
-	service.Schedule = r.FormValue("schedule")
-	service.DistanceWork = r.FormValue("distance_work")
-	service.PaymentPeriod = r.FormValue("payment_period")
-	service.Latitude = r.FormValue("latitude")
-	service.Longitude = r.FormValue("longitude")
-	now := time.Now()
-	service.UpdatedAt = &now
+	existingService, err := h.Service.GetWorkByID(r.Context(), id, 0)
+	if err != nil {
+		http.Error(w, "Service not found", http.StatusNotFound)
+		return
+	}
 
-	// Обработка изображений
+	service := existingService
+
+	if _, ok := r.MultipartForm.Value["name"]; ok {
+		service.Name = r.FormValue("name")
+	}
+	if _, ok := r.MultipartForm.Value["address"]; ok {
+		service.Address = r.FormValue("address")
+	}
+	if v, ok := r.MultipartForm.Value["price"]; ok {
+		service.Price, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if v, ok := r.MultipartForm.Value["user_id"]; ok {
+		service.UserID, _ = strconv.Atoi(v[0])
+	}
+	if _, ok := r.MultipartForm.Value["description"]; ok {
+		service.Description = r.FormValue("description")
+	}
+	if v, ok := r.MultipartForm.Value["category_id"]; ok {
+		service.CategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["subcategory_id"]; ok {
+		service.SubcategoryID, _ = strconv.Atoi(v[0])
+	}
+	if v, ok := r.MultipartForm.Value["avg_rating"]; ok {
+		service.AvgRating, _ = strconv.ParseFloat(v[0], 64)
+	}
+	if _, ok := r.MultipartForm.Value["top"]; ok {
+		service.Top = r.FormValue("top")
+	}
+	if _, ok := r.MultipartForm.Value["liked"]; ok {
+		service.Liked = r.FormValue("liked") == "true"
+	}
+	if _, ok := r.MultipartForm.Value["status"]; ok {
+		service.Status = r.FormValue("status")
+	}
+	if _, ok := r.MultipartForm.Value["work_experience"]; ok {
+		service.WorkExperience = r.FormValue("work_experience")
+	}
+	if v, ok := r.MultipartForm.Value["city_id"]; ok {
+		service.CityID, _ = strconv.Atoi(v[0])
+	}
+	if _, ok := r.MultipartForm.Value["schedule"]; ok {
+		service.Schedule = r.FormValue("schedule")
+	}
+	if _, ok := r.MultipartForm.Value["distance_work"]; ok {
+		service.DistanceWork = r.FormValue("distance_work")
+	}
+	if _, ok := r.MultipartForm.Value["payment_period"]; ok {
+		service.PaymentPeriod = r.FormValue("payment_period")
+	}
+	if _, ok := r.MultipartForm.Value["latitude"]; ok {
+		service.Latitude = r.FormValue("latitude")
+	}
+	if _, ok := r.MultipartForm.Value["longitude"]; ok {
+		service.Longitude = r.FormValue("longitude")
+	}
+
 	saveDir := "cmd/uploads/works"
 	err = os.MkdirAll(saveDir, 0755)
 	if err != nil {
@@ -479,43 +518,45 @@ func (h *WorkHandler) UpdateWork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files := r.MultipartForm.File["images"]
-	var imageInfos []models.ImageWork
+	if files, ok := r.MultipartForm.File["images"]; ok && len(files) > 0 {
+		var imageInfos []models.ImageWork
+		for _, fileHeader := range files {
+			file, err := fileHeader.Open()
+			if err != nil {
+				http.Error(w, "Failed to open image", http.StatusInternalServerError)
+				return
+			}
+			defer file.Close()
 
-	for _, fileHeader := range files {
-		file, err := fileHeader.Open()
-		if err != nil {
-			http.Error(w, "Failed to open image", http.StatusInternalServerError)
-			return
+			timestamp := time.Now().UnixNano()
+			ext := filepath.Ext(fileHeader.Filename)
+			imageName := fmt.Sprintf("work_image_%d%s", timestamp, ext)
+			savePath := filepath.Join(saveDir, imageName)
+			publicURL := fmt.Sprintf("/images/works/%s", imageName)
+
+			dst, err := os.Create(savePath)
+			if err != nil {
+				http.Error(w, "Cannot save image", http.StatusInternalServerError)
+				return
+			}
+			defer dst.Close()
+
+			if _, err := io.Copy(dst, file); err != nil {
+				http.Error(w, "Failed to write image", http.StatusInternalServerError)
+				return
+			}
+
+			imageInfos = append(imageInfos, models.ImageWork{
+				Name: fileHeader.Filename,
+				Path: publicURL,
+				Type: fileHeader.Header.Get("Content-Type"),
+			})
 		}
-		defer file.Close()
-
-		timestamp := time.Now().UnixNano()
-		ext := filepath.Ext(fileHeader.Filename)
-		imageName := fmt.Sprintf("work_image_%d%s", timestamp, ext)
-		savePath := filepath.Join(saveDir, imageName)
-		publicURL := fmt.Sprintf("/images/works/%s", imageName)
-
-		dst, err := os.Create(savePath)
-		if err != nil {
-			http.Error(w, "Cannot save image", http.StatusInternalServerError)
-			return
-		}
-		defer dst.Close()
-
-		if _, err := io.Copy(dst, file); err != nil {
-			http.Error(w, "Failed to write image", http.StatusInternalServerError)
-			return
-		}
-
-		imageInfos = append(imageInfos, models.ImageWork{
-			Name: fileHeader.Filename,
-			Path: publicURL,
-			Type: fileHeader.Header.Get("Content-Type"),
-		})
+		service.Images = imageInfos
 	}
 
-	service.Images = imageInfos
+	now := time.Now()
+	service.UpdatedAt = &now
 
 	updatedService, err := h.Service.UpdateWork(r.Context(), service)
 	if err != nil {


### PR DESCRIPTION
## Summary
- fetch existing service/ad/rent/work records before updating
- only overwrite fields present in the request so missing data like images stays unchanged

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c3d1bc7a388324b9554364927717cd