### PR TITLE
Remove phone requirement for email code endpoint

### DIFF
--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -363,17 +363,15 @@ func (h *UserHandler) ChangeEmail(w http.ResponseWriter, r *http.Request) {
 
 func (h *UserHandler) SendCodeToEmail(w http.ResponseWriter, r *http.Request) {
 	var req struct {
-		Phone string `json:"phone"`
 		Email string `json:"email"`
 	}
 
-	err := json.NewDecoder(r.Body).Decode(&req)
-	if err != nil || req.Phone == "" || req.Email == "" {
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Email == "" {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
 	}
 
-	resp, err := h.Service.SendCodeToEmail(r.Context(), req.Phone, req.Email)
+	resp, err := h.Service.SendCodeToEmail(r.Context(), req.Email)
 	if err != nil {
 		if errors.Is(err, models.ErrDuplicateEmail) {
 			http.Error(w, err.Error(), http.StatusConflict)


### PR DESCRIPTION
## Summary
- accept only email in `/user/send_email_code` request
- verify and store email codes without phone
- check signup codes by email

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c3e8f7d8708324a63016ce28b8a580