### PR TITLE
Add email column for verification codes

### DIFF
--- a/db/migrations/000063_verification_codes_email.down.sql
+++ b/db/migrations/000063_verification_codes_email.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE verification_codes
+    DROP COLUMN email,
+    MODIFY phone VARCHAR(20) NOT NULL;

--- a/db/migrations/000063_verification_codes_email.up.sql
+++ b/db/migrations/000063_verification_codes_email.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE verification_codes
+    MODIFY phone VARCHAR(20) NULL,
+    ADD COLUMN email VARCHAR(255) DEFAULT NULL AFTER phone;


### PR DESCRIPTION
## Summary
- allow storing email verification codes by adding nullable `email` column to `verification_codes`
- permit empty `phone` in `verification_codes` so email codes can be saved without error

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c3f1ca5d608324b43b37dec00a137c