### PR TITLE
Hide phone numbers in filtered and detail endpoints

### DIFF
--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -14,7 +14,7 @@ type Ad struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -74,7 +74,7 @@ type FilteredAd struct {
 	UserID           int     `json:"user_id"`
 	UserName         string  `json:"user_name"`
 	UserSurname      string  `json:"user_surname"`
-	UserPhone        string  `json:"user_phone"`
+	UserPhone        string  `json:"-"`
 	UserAvatarPath   *string `json:"user_avatar_path,omitempty"`
 	UserRating       float64 `json:"user_rating"`
 	UserReviewsCount int     `json:"user_reviews_count"`

--- a/internal/models/rent.go
+++ b/internal/models/rent.go
@@ -14,7 +14,7 @@ type Rent struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -76,7 +76,7 @@ type FilteredRent struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
+	UserPhone          string  `json:"-"`
 	UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
 	UserRating         float64 `json:"user_rating"`
 	UserReviewsCount   int     `json:"user_reviews_count"`

--- a/internal/models/rent_ad.go
+++ b/internal/models/rent_ad.go
@@ -14,7 +14,7 @@ type RentAd struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -76,7 +76,7 @@ type FilteredRentAd struct {
 	UserID            int     `json:"user_id"`
 	UserName          string  `json:"user_name"`
 	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"user_phone"`
+	UserPhone         string  `json:"-"`
 	UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
 	UserRating        float64 `json:"user_rating"`
 	UserReviewsCount  int     `json:"user_reviews_count"`

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -14,7 +14,7 @@ type Service struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -75,7 +75,7 @@ type FilteredService struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
+	UserPhone          string  `json:"-"`
 	UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
 	UserRating         float64 `json:"user_rating"`
 	UserReviewsCount   int     `json:"user_reviews_count"`

--- a/internal/models/work.go
+++ b/internal/models/work.go
@@ -14,7 +14,7 @@ type Work struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -81,7 +81,7 @@ type FilteredWork struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
+	UserPhone          string  `json:"-"`
 	UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
 	UserRating         float64 `json:"user_rating"`
 	UserReviewsCount   int     `json:"user_reviews_count"`

--- a/internal/models/work_ad.go
+++ b/internal/models/work_ad.go
@@ -14,7 +14,7 @@ type WorkAd struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -82,7 +82,7 @@ type FilteredWorkAd struct {
 	UserID            int     `json:"user_id"`
 	UserName          string  `json:"user_name"`
 	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"user_phone"`
+	UserPhone         string  `json:"-"`
 	UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
 	UserRating        float64 `json:"user_rating"`
 	UserReviewsCount  int     `json:"user_reviews_count"`


### PR DESCRIPTION
## Summary
- stop exposing user phone numbers in Service, Ad, Rent, Rent Ad, Work, and Work Ad responses

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c7d3c6ea348324b59bd097f059aea3