### PR TITLE
Hide phone numbers except for in-progress chats

### DIFF
--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -14,7 +14,7 @@ type Ad struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -74,7 +74,7 @@ type FilteredAd struct {
 	UserID           int     `json:"user_id"`
 	UserName         string  `json:"user_name"`
 	UserSurname      string  `json:"user_surname"`
-	UserPhone        string  `json:"user_phone"`
+	UserPhone        string  `json:"-"`
 	UserAvatarPath   *string `json:"user_avatar_path,omitempty"`
 	UserRating       float64 `json:"user_rating"`
 	UserReviewsCount int     `json:"user_reviews_count"`

--- a/internal/models/chats_by_user.go
+++ b/internal/models/chats_by_user.go
@@ -6,6 +6,7 @@ type ChatUser struct {
 	Name         string  `json:"name"`
 	Surname      string  `json:"surname"`
 	AvatarPath   string  `json:"avatar_path"`
+	Phone        string  `json:"phone,omitempty"`
 	Price        float64 `json:"price"`
 	ChatID       int     `json:"chat_id"`
 	ReviewRating float64 `json:"review_rating"`

--- a/internal/models/rent.go
+++ b/internal/models/rent.go
@@ -14,7 +14,7 @@ type Rent struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -76,7 +76,7 @@ type FilteredRent struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
+	UserPhone          string  `json:"-"`
 	UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
 	UserRating         float64 `json:"user_rating"`
 	UserReviewsCount   int     `json:"user_reviews_count"`

--- a/internal/models/rent_ad.go
+++ b/internal/models/rent_ad.go
@@ -14,7 +14,7 @@ type RentAd struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -76,7 +76,7 @@ type FilteredRentAd struct {
 	UserID            int     `json:"user_id"`
 	UserName          string  `json:"user_name"`
 	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"user_phone"`
+	UserPhone         string  `json:"-"`
 	UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
 	UserRating        float64 `json:"user_rating"`
 	UserReviewsCount  int     `json:"user_reviews_count"`

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -14,7 +14,7 @@ type Service struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -75,7 +75,7 @@ type FilteredService struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
+	UserPhone          string  `json:"-"`
 	UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
 	UserRating         float64 `json:"user_rating"`
 	UserReviewsCount   int     `json:"user_reviews_count"`

--- a/internal/models/work.go
+++ b/internal/models/work.go
@@ -14,7 +14,7 @@ type Work struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -81,7 +81,7 @@ type FilteredWork struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
+	UserPhone          string  `json:"-"`
 	UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
 	UserRating         float64 `json:"user_rating"`
 	UserReviewsCount   int     `json:"user_reviews_count"`

--- a/internal/models/work_ad.go
+++ b/internal/models/work_ad.go
@@ -14,7 +14,7 @@ type WorkAd struct {
 		ID           int     `json:"id"`
 		Name         string  `json:"name"`
 		Surname      string  `json:"surname"`
-		Phone        string  `json:"phone"`
+		Phone        string  `json:"-"`
 		ReviewRating float64 `json:"review_rating"`
 		ReviewsCount int     `json:"reviews_count"`
 		AvatarPath   *string `json:"avatar_path,omitempty"`
@@ -82,7 +82,7 @@ type FilteredWorkAd struct {
 	UserID            int     `json:"user_id"`
 	UserName          string  `json:"user_name"`
 	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"user_phone"`
+	UserPhone         string  `json:"-"`
 	UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
 	UserRating        float64 `json:"user_rating"`
 	UserReviewsCount  int     `json:"user_reviews_count"`

--- a/internal/repositories/chat_repository.go
+++ b/internal/repositories/chat_repository.go
@@ -97,7 +97,7 @@ func (r *ChatRepository) DeleteChat(ctx context.Context, id int) error {
 // GetChatsByUserID retrieves chats grouped by advertisements for a specific author.
 func (r *ChatRepository) GetChatsByUserID(ctx context.Context, userID int) ([]models.AdChats, error) {
 	query := `
-SELECT a.id, a.name, a.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, ar.price, ac.chat_id, 'customer' AS my_role
+SELECT a.id, a.name, a.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, u.phone, ar.price, ac.chat_id, 'customer' AS my_role
 FROM ad a
 JOIN ad_confirmations ac ON ac.ad_id = a.id
 JOIN users u ON u.id = ac.performer_id
@@ -107,7 +107,7 @@ WHERE a.user_id = ?
 
 UNION ALL
 
-SELECT a.id, a.name, a.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, ar.price, ac.chat_id, 'performer' AS my_role
+SELECT a.id, a.name, a.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, owner.phone, ar.price, ac.chat_id, 'performer' AS my_role
 FROM ad a
 JOIN ad_confirmations ac ON ac.ad_id = a.id
 JOIN users owner ON owner.id = a.user_id
@@ -117,7 +117,7 @@ WHERE ac.performer_id = ?
 
 UNION ALL
 
-SELECT s.id, s.name, s.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, sr.price, sc.chat_id, 'customer' AS my_role
+SELECT s.id, s.name, s.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, u.phone, sr.price, sc.chat_id, 'customer' AS my_role
 FROM service s
 JOIN service_confirmations sc ON sc.service_id = s.id
 JOIN users u ON u.id = sc.performer_id
@@ -127,7 +127,7 @@ WHERE s.user_id = ?
 
 UNION ALL
 
-SELECT s.id, s.name, s.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, sr.price, sc.chat_id, 'performer' AS my_role
+SELECT s.id, s.name, s.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, owner.phone, sr.price, sc.chat_id, 'performer' AS my_role
 FROM service s
 JOIN service_confirmations sc ON sc.service_id = s.id
 JOIN users owner ON owner.id = s.user_id
@@ -137,7 +137,7 @@ WHERE sc.performer_id = ?
 
 UNION ALL
 
-SELECT ra.id, ra.name, ra.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, rar.price, rac.chat_id, 'customer' AS my_role
+SELECT ra.id, ra.name, ra.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, u.phone, rar.price, rac.chat_id, 'customer' AS my_role
 FROM rent_ad ra
 JOIN rent_ad_confirmations rac ON rac.rent_ad_id = ra.id
 JOIN users u ON u.id = rac.performer_id
@@ -147,7 +147,7 @@ WHERE ra.user_id = ?
 
 UNION ALL
 
-SELECT ra.id, ra.name, ra.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, rar.price, rac.chat_id, 'performer' AS my_role
+SELECT ra.id, ra.name, ra.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, owner.phone, rar.price, rac.chat_id, 'performer' AS my_role
 FROM rent_ad ra
 JOIN rent_ad_confirmations rac ON rac.rent_ad_id = ra.id
 JOIN users owner ON owner.id = ra.user_id
@@ -157,7 +157,7 @@ WHERE rac.performer_id = ?
 
 UNION ALL
 
-SELECT wa.id, wa.name, wa.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, war.price, wac.chat_id, 'customer' AS my_role
+SELECT wa.id, wa.name, wa.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, u.phone, war.price, wac.chat_id, 'customer' AS my_role
 FROM work_ad wa
 JOIN work_ad_confirmations wac ON wac.work_ad_id = wa.id
 JOIN users u ON u.id = wac.performer_id
@@ -167,7 +167,7 @@ WHERE wa.user_id = ?
 
 UNION ALL
 
-SELECT wa.id, wa.name, wa.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, war.price, wac.chat_id, 'performer' AS my_role
+SELECT wa.id, wa.name, wa.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, owner.phone, war.price, wac.chat_id, 'performer' AS my_role
 FROM work_ad wa
 JOIN work_ad_confirmations wac ON wac.work_ad_id = wa.id
 JOIN users owner ON owner.id = wa.user_id
@@ -177,7 +177,7 @@ WHERE wac.performer_id = ?
 
 UNION ALL
 
-SELECT r.id, r.name, r.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, rr.price, rc.chat_id, 'customer' AS my_role
+SELECT r.id, r.name, r.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, u.phone, rr.price, rc.chat_id, 'customer' AS my_role
 FROM rent r
 JOIN rent_confirmations rc ON rc.rent_id = r.id
 JOIN users u ON u.id = rc.performer_id
@@ -187,7 +187,7 @@ WHERE r.user_id = ?
 
 UNION ALL
 
-SELECT r.id, r.name, r.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, rr.price, rc.chat_id, 'performer' AS my_role
+SELECT r.id, r.name, r.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, owner.phone, rr.price, rc.chat_id, 'performer' AS my_role
 FROM rent r
 JOIN rent_confirmations rc ON rc.rent_id = r.id
 JOIN users owner ON owner.id = r.user_id
@@ -197,7 +197,7 @@ WHERE rc.performer_id = ?
 
 UNION ALL
 
-SELECT w.id, w.name, w.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, wr.price, wc.chat_id, 'customer' AS my_role
+SELECT w.id, w.name, w.status, c.performer_id, u.id, u.name, u.surname, COALESCE(u.avatar_path, '') AS avatar_path, u.phone, wr.price, wc.chat_id, 'customer' AS my_role
 FROM work w
 JOIN work_confirmations wc ON wc.work_id = w.id
 JOIN users u ON u.id = wc.performer_id
@@ -207,7 +207,7 @@ WHERE w.user_id = ?
 
 UNION ALL
 
-SELECT w.id, w.name, w.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, wr.price, wc.chat_id, 'performer' AS my_role
+SELECT w.id, w.name, w.status, c.performer_id, owner.id, owner.name, owner.surname, COALESCE(owner.avatar_path, '') AS avatar_path, owner.phone, wr.price, wc.chat_id, 'performer' AS my_role
 FROM work w
 JOIN work_confirmations wc ON wc.work_id = w.id
 JOIN users owner ON owner.id = w.user_id
@@ -242,10 +242,14 @@ ORDER BY 1
 		var user models.ChatUser
 		if err := rows.Scan(
 			&adID, &adName, &status, &confirmedPerformer,
-			&user.ID, &user.Name, &user.Surname, &user.AvatarPath,
+			&user.ID, &user.Name, &user.Surname, &user.AvatarPath, &user.Phone,
 			&user.Price, &user.ChatID, &user.MyRole,
 		); err != nil {
 			return nil, err
+		}
+
+		if status != "in progress" {
+			user.Phone = ""
 		}
 
 		// рейтинг/отзывы как было


### PR DESCRIPTION
## Summary
- stop exposing user phone numbers in Service, Ad, Rent, Rent Ad, Work, and Work Ad responses
- expose phone numbers in chat listings only when the related item status is `in progress`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c7d3c6ea348324b59bd097f059aea3