### PR TITLE
Remove verification code from email endpoint

### DIFF
--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -371,7 +371,7 @@ func (h *UserHandler) SendCodeToEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.Service.SendCodeToEmail(r.Context(), req.Email)
+	err := h.Service.SendCodeToEmail(r.Context(), req.Email)
 	if err != nil {
 		if errors.Is(err, models.ErrDuplicateEmail) {
 			http.Error(w, err.Error(), http.StatusConflict)
@@ -384,7 +384,7 @@ func (h *UserHandler) SendCodeToEmail(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(resp)
+	json.NewEncoder(w).Encode(map[string]string{"message": "verification code sent"})
 }
 
 func (h *UserHandler) ChangeCityForUser(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- stop returning verification code in SendCodeToEmail API

## Testing
- `go test ./...` *(fails: no output in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c810b0a8188324bc0b41fa65f49f29