### PR TITLE
Use token city for all entity searches

### DIFF
--- a/internal/handlers/ad_handler.go
+++ b/internal/handlers/ad_handler.go
@@ -127,7 +127,7 @@ func (h *AdHandler) GetAd(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	cityID := 0
+	cityID, _ := strconv.Atoi(r.URL.Query().Get("city_id"))
 	tokenString := r.Header.Get("Authorization")
 	if strings.HasPrefix(tokenString, "Bearer ") {
 		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
@@ -135,7 +135,7 @@ func (h *AdHandler) GetAd(w http.ResponseWriter, r *http.Request) {
 		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 			return []byte(signingKey), nil
 		})
-		if err == nil && token.Valid {
+		if err == nil && token.Valid && cityID == 0 {
 			cityID = claims.CityID
 		}
 	}
@@ -250,6 +250,19 @@ func (h *AdHandler) GetFilteredAdPost(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	ads, err := h.Service.GetFilteredAdPost(r.Context(), req)
@@ -531,6 +544,19 @@ func (h *AdHandler) GetFilteredAdWithLikes(w http.ResponseWriter, r *http.Reques
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	ads, err := h.Service.GetFilteredAdWithLikes(r.Context(), req, userID)

--- a/internal/handlers/rent_ad_handler.go
+++ b/internal/handlers/rent_ad_handler.go
@@ -127,7 +127,7 @@ func (h *RentAdHandler) GetRentsAd(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	cityID := 0
+	cityID, _ := strconv.Atoi(r.URL.Query().Get("city_id"))
 	tokenString := r.Header.Get("Authorization")
 	if strings.HasPrefix(tokenString, "Bearer ") {
 		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
@@ -135,7 +135,7 @@ func (h *RentAdHandler) GetRentsAd(w http.ResponseWriter, r *http.Request) {
 		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 			return []byte(signingKey), nil
 		})
-		if err == nil && token.Valid {
+		if err == nil && token.Valid && cityID == 0 {
 			cityID = claims.CityID
 		}
 	}
@@ -250,6 +250,19 @@ func (h *RentAdHandler) GetFilteredRentsAdPost(w http.ResponseWriter, r *http.Re
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	rents, err := h.Service.GetFilteredRentsAdPost(r.Context(), req)
@@ -538,6 +551,19 @@ func (h *RentAdHandler) GetFilteredRentsAdWithLikes(w http.ResponseWriter, r *ht
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	rents_ad, err := h.Service.GetFilteredRentsAdWithLikes(r.Context(), req, userID)

--- a/internal/handlers/rent_handler.go
+++ b/internal/handlers/rent_handler.go
@@ -127,7 +127,7 @@ func (h *RentHandler) GetRents(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	cityID := 0
+	cityID, _ := strconv.Atoi(r.URL.Query().Get("city_id"))
 	tokenString := r.Header.Get("Authorization")
 	if strings.HasPrefix(tokenString, "Bearer ") {
 		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
@@ -135,7 +135,7 @@ func (h *RentHandler) GetRents(w http.ResponseWriter, r *http.Request) {
 		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 			return []byte(signingKey), nil
 		})
-		if err == nil && token.Valid {
+		if err == nil && token.Valid && cityID == 0 {
 			cityID = claims.CityID
 		}
 	}
@@ -250,6 +250,19 @@ func (h *RentHandler) GetFilteredRentsPost(w http.ResponseWriter, r *http.Reques
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	rents, err := h.Service.GetFilteredRentsPost(r.Context(), req)
@@ -550,6 +563,19 @@ func (h *RentHandler) GetFilteredRentsWithLikes(w http.ResponseWriter, r *http.R
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	rents, err := h.Service.GetFilteredRentsWithLikes(r.Context(), req, userID)

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -127,7 +127,7 @@ func (h *ServiceHandler) GetServices(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	cityID := 0
+	cityID, _ := strconv.Atoi(r.URL.Query().Get("city_id"))
 	tokenString := r.Header.Get("Authorization")
 	if strings.HasPrefix(tokenString, "Bearer ") {
 		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
@@ -135,7 +135,7 @@ func (h *ServiceHandler) GetServices(w http.ResponseWriter, r *http.Request) {
 		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 			return []byte(signingKey), nil
 		})
-		if err == nil && token.Valid {
+		if err == nil && token.Valid && cityID == 0 {
 			cityID = claims.CityID
 		}
 	}
@@ -250,6 +250,20 @@ func (h *ServiceHandler) GetFilteredServicesPost(w http.ResponseWriter, r *http.
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	services, err := h.Service.GetFilteredServicesPost(r.Context(), req)
@@ -548,6 +562,20 @@ func (h *ServiceHandler) GetFilteredServicesWithLikes(w http.ResponseWriter, r *
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "Invalid request body", http.StatusBadRequest)
 		return
+	}
+
+	tokenString := r.Header.Get("Authorization")
+	if strings.HasPrefix(tokenString, "Bearer ") {
+		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
+		claims := &models.Claims{}
+		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
+			return []byte(signingKey), nil
+		})
+		if err == nil && token.Valid {
+			if req.CityID == 0 {
+				req.CityID = claims.CityID
+			}
+		}
 	}
 
 	services, err := h.Service.GetFilteredServicesWithLikes(r.Context(), req, userID)

--- a/internal/handlers/work_ad_handler.go
+++ b/internal/handlers/work_ad_handler.go
@@ -127,7 +127,7 @@ func (h *WorkAdHandler) GetWorksAd(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	cityID := 0
+	cityID, _ := strconv.Atoi(r.URL.Query().Get("city_id"))
 	tokenString := r.Header.Get("Authorization")
 	if strings.HasPrefix(tokenString, "Bearer ") {
 		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
@@ -135,7 +135,7 @@ func (h *WorkAdHandler) GetWorksAd(w http.ResponseWriter, r *http.Request) {
 		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 			return []byte(signingKey), nil
 		})
-		if err == nil && token.Valid {
+		if err == nil && token.Valid && cityID == 0 {
 			cityID = claims.CityID
 		}
 	}

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -127,7 +127,7 @@ func (h *WorkHandler) GetWorks(w http.ResponseWriter, r *http.Request) {
 		Limit:         limit,
 	}
 
-	cityID := 0
+	cityID, _ := strconv.Atoi(r.URL.Query().Get("city_id"))
 	tokenString := r.Header.Get("Authorization")
 	if strings.HasPrefix(tokenString, "Bearer ") {
 		tokenString = strings.TrimPrefix(tokenString, "Bearer ")
@@ -135,7 +135,7 @@ func (h *WorkHandler) GetWorks(w http.ResponseWriter, r *http.Request) {
 		token, err := jwt.ParseWithClaims(tokenString, claims, func(token *jwt.Token) (interface{}, error) {
 			return []byte(signingKey), nil
 		})
-		if err == nil && token.Valid {
+		if err == nil && token.Valid && cityID == 0 {
 			cityID = claims.CityID
 		}
 	}


### PR DESCRIPTION
## Summary
- default city filter to user's JWT city across Service, Ad, Rent, Rent Ad, Work and Work Ad search handlers
- allow unauthenticated requests to specify city id while letting authenticated users override their token city

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c8168d55408324b34e498a91b29ed4