### PR TITLE
Fix boolean liked flags in filtered listing queries

### DIFF
--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -187,7 +187,7 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, cityID 
                SELECT s.id, s.name, s.address, s.price, s.user_id,
                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                       s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top,
-                      CASE WHEN sf.ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked,
+                     CASE WHEN sf.ad_id IS NOT NULL THEN true ELSE false END AS liked,
                       s.latitude, s.longitude, s.status,  s.created_at, s.updated_at
                FROM ad s
                LEFT JOIN ad_favorites sf ON sf.ad_id = s.id AND sf.user_id = ?

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -183,7 +183,7 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 	)
 
 	baseQuery := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+              SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_ad_id IS NOT NULL THEN true ELSE false END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM rent_ad s
                LEFT JOIN rent_ad_favorites sf ON sf.rent_ad_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -183,7 +183,7 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ci
 	)
 
 	baseQuery := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+              SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_id IS NOT NULL THEN true ELSE false END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM rent s
                LEFT JOIN rent_favorites sf ON sf.rent_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -190,7 +190,7 @@ func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID i
                      u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                      s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top,
                      s.latitude, s.longitude,
-                     CASE WHEN sf.service_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked,
+             CASE WHEN sf.service_id IS NOT NULL THEN true ELSE false END AS liked,
                      s.status,  s.created_at, s.updated_at
               FROM service s
               LEFT JOIN service_favorites sf ON sf.service_id = s.id AND sf.user_id = ?

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -180,7 +180,7 @@ func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int
 	)
 
 	baseQuery := `
-       SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.work_ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+       SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.work_ad_id IS NOT NULL THEN true ELSE false END AS liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM work_ad s
                LEFT JOIN work_ad_favorites sf ON sf.work_ad_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -186,7 +186,7 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ci
                SELECT s.id, s.name, s.address, s.price, s.user_id,
                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
                       s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top,
-                     CASE WHEN sf.work_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked,
+                     CASE WHEN sf.work_id IS NOT NULL THEN true ELSE false END AS liked,
                      s.status, s.work_experience, s.city_id, city.name, city.type, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
               FROM work s
               LEFT JOIN work_favorites sf ON sf.work_id = s.id AND sf.user_id = ?


### PR DESCRIPTION
## Summary
- return real boolean values for the `liked` column in filtered queries for services, ads, rents, rent ads, work, and work ads so scans into Go booleans succeed

## Testing
- go test ./... *(fails: command hung in this environment and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c90f20f9e88324be0337e07e67c42e