### PR TITLE
Remove phone selection from listing repositories

### DIFF
--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -63,8 +63,8 @@ func (r *AdRepository) CreateAd(ctx context.Context, ad models.Ad) (models.Ad, e
 
 func (r *AdRepository) GetAdByID(ctx context.Context, id int, userID int) (models.Ad, error) {
 	query := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id,
-                      u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+             SELECT s.id, s.name, s.address, s.price, s.user_id,
+                    u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                       s.images, s.category_id, c.name, s.subcategory_id, sub.name,
                       s.description, s.avg_rating, s.top, s.liked,
                       CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded,
@@ -82,7 +82,7 @@ func (r *AdRepository) GetAdByID(ctx context.Context, id int, userID int) (model
 	var lat, lon sql.NullString
 	err := r.DB.QueryRowContext(ctx, query, userID, id).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Responded, &lat, &lon, &s.Status,
 		&s.CreatedAt, &s.UpdatedAt,
 	)
@@ -184,10 +184,10 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, cityID 
 	)
 
 	baseQuery := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id,
-                      u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+            SELECT s.id, s.name, s.address, s.price, s.user_id,
+                   u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                       s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top,
-                      CASE WHEN sf.ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked,
+                     CASE WHEN sf.ad_id IS NOT NULL THEN true ELSE false END AS liked,
                       s.latitude, s.longitude, s.status,  s.created_at, s.updated_at
                FROM ad s
                LEFT JOIN ad_favorites sf ON sf.ad_id = s.id AND sf.user_id = ?
@@ -271,7 +271,7 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, cityID 
 		var lat, lon sql.NullString
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &lat, &lon, &s.Status,
 			&s.CreatedAt, &s.UpdatedAt,
 		)
@@ -361,9 +361,9 @@ func (r *AdRepository) GetAdByUserID(ctx context.Context, userID int) ([]models.
 
 func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterAdRequest) ([]models.FilteredAd, error) {
 	query := `
-      SELECT
+       SELECT
 
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+               u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
               s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM ad s
@@ -433,7 +433,7 @@ func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterA
 		var s models.FilteredAd
 		var lat, lon sql.NullString
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
 			&s.AdID, &s.AdName, &s.AdPrice, &s.AdDescription, &lat, &lon,
 		); err != nil {
@@ -459,7 +459,7 @@ func (r *AdRepository) FetchAdByStatusAndUserID(ctx context.Context, userID int,
 	query := `
         SELECT
                 s.id, s.name, s.address, s.price, s.user_id,
-                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                 s.images, s.category_id, s.subcategory_id, s.description,
                 s.avg_rating, s.top, s.liked, s.status,
                 s.created_at, s.updated_at
@@ -479,7 +479,7 @@ func (r *AdRepository) FetchAdByStatusAndUserID(ctx context.Context, userID int,
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status,
 			&s.CreatedAt, &s.UpdatedAt,
@@ -500,9 +500,9 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-   SELECT DISTINCT
+    SELECT DISTINCT
 
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
            s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
@@ -592,7 +592,7 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 		var s models.FilteredAd
 		var lat, lon sql.NullString
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
 			&s.AdID, &s.AdName, &s.AdPrice, &s.AdDescription, &lat, &lon, &s.Liked, &s.Responded,
 		); err != nil {
@@ -623,9 +623,9 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 
 func (r *AdRepository) GetAdByAdIDAndUserID(ctx context.Context, adID int, userID int) (models.Ad, error) {
 	query := `
-               SELECT
-                       s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+            SELECT
+                    s.id, s.name, s.address, s.price, s.user_id,
+                    u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -647,7 +647,7 @@ func (r *AdRepository) GetAdByAdIDAndUserID(ctx context.Context, adID int, userI
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, adID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,
@@ -689,7 +689,7 @@ func (r *AdRepository) GetAds(ctx context.Context, filter models.AdsFilter) ([]m
                s.category_id, c.name as category_name, s.subcategory_id, sub.name as subcategory_name,
                0 as views_count,
                (SELECT COUNT(*) FROM service_responses sr WHERE sr.service_id = s.id) as responses_count,
-               u.id as author_id, u.name as author_name, u.review_rating as author_rating, u.phone as author_phone,
+               u.id as author_id, u.name as author_name, u.review_rating as author_rating,
                '' as author_chat_link,
                NULL as work_scope, NULL as deposit_required, NULL as rental_terms,
                NULL as employment_type, NULL as salary_from, NULL as salary_to
@@ -704,7 +704,7 @@ func (r *AdRepository) GetAds(ctx context.Context, filter models.AdsFilter) ([]m
                r.category_id, rc.name as category_name, r.subcategory_id, rsub.name as subcategory_name,
                0 as views_count,
                (SELECT COUNT(*) FROM rent_ad_responses rr WHERE rr.rent_ad_id = r.id) as responses_count,
-               u.id as author_id, u.name as author_name, u.review_rating as author_rating, u.phone as author_phone,
+               u.id as author_id, u.name as author_name, u.review_rating as author_rating,
                '' as author_chat_link,
                NULL as work_scope, r.deposit as deposit_required, r.rent_type as rental_terms,
                NULL as employment_type, NULL as salary_from, NULL as salary_to
@@ -719,7 +719,7 @@ func (r *AdRepository) GetAds(ctx context.Context, filter models.AdsFilter) ([]m
                w.category_id, c.name as category_name, w.subcategory_id, sub.name as subcategory_name,
                0 as views_count,
                (SELECT COUNT(*) FROM work_ad_responses wr WHERE wr.work_ad_id = w.id) as responses_count,
-               u.id as author_id, u.name as author_name, u.review_rating as author_rating, u.phone as author_phone,
+               u.id as author_id, u.name as author_name, u.review_rating as author_rating,
                '' as author_chat_link,
                NULL as work_scope, NULL as deposit_required, NULL as rental_terms,
                w.schedule as employment_type, NULL as salary_from, NULL as salary_to
@@ -810,7 +810,6 @@ func (r *AdRepository) GetAds(ctx context.Context, filter models.AdsFilter) ([]m
 			&item.Author.ID,
 			&item.Author.Name,
 			&authorRating,
-			&item.Author.Phone,
 			&authorChat,
 			&workScope,
 			&depositReq,

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -66,7 +66,7 @@ func (r *RentAdRepository) CreateRentAd(ctx context.Context, rent models.RentAd)
 
 func (r *RentAdRepository) GetRentAdByID(ctx context.Context, id int, userID int) (models.RentAd, error) {
 	query := `
-               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked,
+             SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked,
                       CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded,
                       w.status, w.rent_type, w.deposit, w.latitude, w.longitude, w.created_at, w.updated_at
                 FROM rent_ad w
@@ -81,7 +81,7 @@ func (r *RentAdRepository) GetRentAdByID(ctx context.Context, id int, userID int
 	var imagesJSON []byte
 	var lat, lon sql.NullString
 	err := r.DB.QueryRowContext(ctx, query, userID, id).Scan(
-		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Responded, &s.Status, &s.RentType, &s.Deposit, &lat, &lon, &s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -183,7 +183,7 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 	)
 
 	baseQuery := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+              SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_ad_id IS NOT NULL THEN true ELSE false END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM rent_ad s
                LEFT JOIN rent_ad_favorites sf ON sf.rent_ad_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id
@@ -264,7 +264,7 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 		var s models.RentAd
 		var imagesJSON []byte
 		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
 		)
 		if err != nil {
@@ -339,9 +339,9 @@ func (r *RentAdRepository) GetRentsAdByUserID(ctx context.Context, userID int) (
 
 func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req models.FilterRentAdRequest) ([]models.FilteredRentAd, error) {
 	query := `
-      SELECT
+       SELECT
 
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+               u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
               s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM rent_ad s
@@ -410,7 +410,7 @@ func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req model
 	for rows.Next() {
 		var s models.FilteredRentAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription, &s.RentAdLatitude, &s.RentAdLongitude,
 		); err != nil {
 			return nil, err
@@ -429,7 +429,7 @@ func (r *RentAdRepository) FetchByStatusAndUserID(ctx context.Context, userID in
 	query := `
         SELECT
                 s.id, s.name, s.address, s.price, s.user_id,
-                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                 s.images, s.category_id, s.subcategory_id, s.description,
                 s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude,
                 s.created_at, s.updated_at
@@ -449,7 +449,7 @@ func (r *RentAdRepository) FetchByStatusAndUserID(ctx context.Context, userID in
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt,
 			&s.UpdatedAt,
@@ -470,9 +470,9 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-   SELECT DISTINCT
+    SELECT DISTINCT
 
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
            s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
@@ -561,7 +561,7 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 	for rows.Next() {
 		var s models.FilteredRentAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription, &s.RentAdLatitude, &s.RentAdLongitude, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
@@ -585,9 +585,9 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 
 func (r *RentAdRepository) GetRentAdByRentIDAndUserID(ctx context.Context, rentAdID int, userID int) (models.RentAd, error) {
 	query := `
-               SELECT
-                       s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+            SELECT
+                    s.id, s.name, s.address, s.price, s.user_id,
+                    u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -608,7 +608,7 @@ func (r *RentAdRepository) GetRentAdByRentIDAndUserID(ctx context.Context, rentA
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, rentAdID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -66,7 +66,7 @@ func (r *RentRepository) CreateRent(ctx context.Context, rent models.Rent) (mode
 
 func (r *RentRepository) GetRentByID(ctx context.Context, id int, userID int) (models.Rent, error) {
 	query := `
-               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked,
+             SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked,
                       CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded,
                       w.status, w.rent_type, w.deposit, w.latitude, w.longitude, w.created_at, w.updated_at
                 FROM rent w
@@ -81,7 +81,7 @@ func (r *RentRepository) GetRentByID(ctx context.Context, id int, userID int) (m
 	var imagesJSON []byte
 	var lat, lon sql.NullString
 	err := r.DB.QueryRowContext(ctx, query, userID, id).Scan(
-		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Responded, &s.Status, &s.RentType, &s.Deposit, &lat, &lon, &s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -183,7 +183,7 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ci
 	)
 
 	baseQuery := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+           SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.rent_id IS NOT NULL THEN true ELSE false END AS liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM rent s
                LEFT JOIN rent_favorites sf ON sf.rent_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id
@@ -265,7 +265,7 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ci
 		var imagesJSON []byte
 		var lat, lon sql.NullString
 		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &lat, &lon, &s.CreatedAt, &s.UpdatedAt,
 		)
 		if err != nil {
@@ -304,7 +304,7 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ci
 
 func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]models.Rent, error) {
 	query := `
-                SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
+               SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
                 FROM rent s
                 JOIN users u ON s.user_id = u.id
                 WHERE user_id = ?
@@ -322,7 +322,7 @@ func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]mo
 		var imagesJSON []byte
 		var lat, lon sql.NullString
 		if err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
 			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &lat, &lon, &s.CreatedAt, &s.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -354,9 +354,9 @@ func (r *RentRepository) GetRentsByUserID(ctx context.Context, userID int) ([]mo
 
 func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.FilterRentRequest) ([]models.FilteredRent, error) {
 	query := `
-      SELECT
+       SELECT
 
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+               u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
               s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM rent s
@@ -426,7 +426,7 @@ func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.Fi
 		var s models.FilteredRent
 		var lat, lon sql.NullString
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon,
 		); err != nil {
 			return nil, err
@@ -451,7 +451,7 @@ func (r *RentRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 	query := `
         SELECT
                 s.id, s.name, s.address, s.price, s.user_id,
-                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                 s.images, s.category_id, s.subcategory_id, s.description,
                 s.avg_rating, s.top, s.liked, s.status, s.rent_type, s.deposit, s.latitude, s.longitude,
                 s.created_at, s.updated_at
@@ -472,7 +472,7 @@ func (r *RentRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 		var lat, lon sql.NullString
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.RentType, &s.Deposit, &lat, &lon, &s.CreatedAt,
 			&s.UpdatedAt,
@@ -499,9 +499,9 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-   SELECT DISTINCT
+    SELECT DISTINCT
 
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
            s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
@@ -591,7 +591,7 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 		var s models.FilteredRent
 		var lat, lon sql.NullString
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
@@ -621,9 +621,9 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 
 func (r *RentRepository) GetRentByRentIDAndUserID(ctx context.Context, rentID int, userID int) (models.Rent, error) {
 	query := `
-               SELECT
-                       s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+            SELECT
+                    s.id, s.name, s.address, s.price, s.user_id,
+                    u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -645,7 +645,7 @@ func (r *RentRepository) GetRentByRentIDAndUserID(ctx context.Context, rentID in
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, rentID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -63,8 +63,8 @@ func (r *ServiceRepository) CreateService(ctx context.Context, service models.Se
 
 func (r *ServiceRepository) GetServiceByID(ctx context.Context, id int, userID int) (models.Service, error) {
 	query := `
-               SELECT s.id, s.name, s.address, s.price, s.user_id,
-                      u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+             SELECT s.id, s.name, s.address, s.price, s.user_id,
+                    u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                       s.images, s.category_id, c.name, s.subcategory_id, sub.name,
                       s.description, s.avg_rating, s.top, s.liked,
                       CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded,
@@ -82,7 +82,7 @@ func (r *ServiceRepository) GetServiceByID(ctx context.Context, id int, userID i
 	var lat, lon sql.NullString
 	err := r.DB.QueryRowContext(ctx, query, userID, id).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Responded,
 		&lat, &lon, &s.Status, &s.CreatedAt, &s.UpdatedAt,
@@ -186,11 +186,11 @@ func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID i
 	)
 
 	baseQuery := `
-              SELECT s.id, s.name, s.address, s.price, s.user_id,
-                     u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+           SELECT s.id, s.name, s.address, s.price, s.user_id,
+                  u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                      s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top,
                      s.latitude, s.longitude,
-                     CASE WHEN sf.service_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked,
+             CASE WHEN sf.service_id IS NOT NULL THEN true ELSE false END AS liked,
                      s.status,  s.created_at, s.updated_at
               FROM service s
               LEFT JOIN service_favorites sf ON sf.service_id = s.id AND sf.user_id = ?
@@ -274,7 +274,7 @@ func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID i
 		var lat, lon sql.NullString
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &lat, &lon, &s.Liked, &s.Status,
 			&s.CreatedAt, &s.UpdatedAt,
 		)
@@ -315,7 +315,7 @@ func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID i
 
 func (r *ServiceRepository) GetServicesByUserID(ctx context.Context, userID int) ([]models.Service, error) {
 	query := `
-              SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.latitude, s.longitude, s.created_at, s.updated_at
+           SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.latitude, s.longitude, s.created_at, s.updated_at
               FROM service s
               JOIN users u ON s.user_id = u.id
               WHERE user_id = ?
@@ -333,7 +333,7 @@ func (r *ServiceRepository) GetServicesByUserID(ctx context.Context, userID int)
 		var imagesJSON []byte
 		var lat, lon sql.NullString
 		if err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
 			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &lat, &lon, &s.CreatedAt, &s.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -366,9 +366,9 @@ func (r *ServiceRepository) GetServicesByUserID(ctx context.Context, userID int)
 
 func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req models.FilterServicesRequest) ([]models.FilteredService, error) {
 	query := `
-      SELECT
+       SELECT
 
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+               u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
               s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM service s
@@ -438,7 +438,7 @@ func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req mod
 		var s models.FilteredService
 		var lat, lon sql.NullString
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
 			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon,
 		); err != nil {
@@ -462,9 +462,9 @@ func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req mod
 
 func (r *ServiceRepository) FetchByStatusAndUserID(ctx context.Context, userID int, status string) ([]models.Service, error) {
 	query := `
-        SELECT
-                s.id, s.name, s.address, s.price, s.user_id,
-                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+     SELECT
+             s.id, s.name, s.address, s.price, s.user_id,
+             u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                 s.images, s.category_id, s.subcategory_id, s.description,
                 s.avg_rating, s.top, s.liked, s.status, s.latitude, s.longitude,
                 s.created_at, s.updated_at
@@ -485,7 +485,7 @@ func (r *ServiceRepository) FetchByStatusAndUserID(ctx context.Context, userID i
 		var lat, lon sql.NullString
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &lat, &lon,
 			&s.CreatedAt, &s.UpdatedAt,
@@ -512,9 +512,9 @@ func (r *ServiceRepository) GetFilteredServicesWithLikes(ctx context.Context, re
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-   SELECT DISTINCT
+    SELECT DISTINCT
 
-          u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
           s.id, s.name, s.price, s.description, s.latitude, s.longitude,
           CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
@@ -597,7 +597,7 @@ func (r *ServiceRepository) GetFilteredServicesWithLikes(ctx context.Context, re
 		var s models.FilteredService
 		var lat, lon sql.NullString
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
 			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon, &s.Liked, &s.Responded,
 		); err != nil {
@@ -628,9 +628,9 @@ func (r *ServiceRepository) GetFilteredServicesWithLikes(ctx context.Context, re
 
 func (r *ServiceRepository) GetServiceByServiceIDAndUserID(ctx context.Context, serviceID int, userID int) (models.Service, error) {
 	query := `
-               SELECT
-                       s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+            SELECT
+                    s.id, s.name, s.address, s.price, s.user_id,
+                    u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -652,7 +652,7 @@ func (r *ServiceRepository) GetServiceByServiceIDAndUserID(ctx context.Context, 
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, serviceID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,

--- a/internal/repositories/work_ad_repository.go
+++ b/internal/repositories/work_ad_repository.go
@@ -69,7 +69,7 @@ func (r *WorkAdRepository) CreateWorkAd(ctx context.Context, work models.WorkAd)
 
 func (r *WorkAdRepository) GetWorkAdByID(ctx context.Context, id int, userID int) (models.WorkAd, error) {
 	query := `
-               SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked,
+             SELECT w.id, w.name, w.address, w.price, w.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked,
                       CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded,
                       w.status, w.work_experience, w.city_id, city.name, city.type, w.schedule, w.distance_work, w.payment_period, w.latitude, w.longitude, w.created_at, w.updated_at
                 FROM work_ad w
@@ -84,7 +84,7 @@ func (r *WorkAdRepository) GetWorkAdByID(ctx context.Context, id int, userID int
 	var s models.WorkAd
 	var imagesJSON []byte
 	err := r.DB.QueryRowContext(ctx, query, userID, id).Scan(
-		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Responded, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.CityType, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -180,7 +180,7 @@ func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int
 	)
 
 	baseQuery := `
-       SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.work_ad_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+       SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, CASE WHEN sf.work_ad_id IS NOT NULL THEN true ELSE false END AS liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM work_ad s
                LEFT JOIN work_ad_favorites sf ON sf.work_ad_id = s.id AND sf.user_id = ?
                JOIN users u ON s.user_id = u.id
@@ -261,7 +261,7 @@ func (r *WorkAdRepository) GetWorksAdWithFilters(ctx context.Context, userID int
 		var s models.WorkAd
 		var imagesJSON []byte
 		err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 			&s.UpdatedAt,
 		)
@@ -338,9 +338,9 @@ func (r *WorkAdRepository) GetWorksAdByUserID(ctx context.Context, userID int) (
 
 func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req models.FilterWorkAdRequest) ([]models.FilteredWorkAd, error) {
 	query := `
-      SELECT
+       SELECT
 
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+               u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
               s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM work_ad s
@@ -409,7 +409,7 @@ func (r *WorkAdRepository) GetFilteredWorksAdPost(ctx context.Context, req model
 	for rows.Next() {
 		var s models.FilteredWorkAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 			&s.WorkAdID, &s.WorkAdName, &s.WorkAdPrice, &s.WorkAdDescription, &s.WorkAdLatitude, &s.WorkAdLongitude,
 		); err != nil {
 			return nil, err
@@ -428,7 +428,7 @@ func (r *WorkAdRepository) FetchByStatusAndUserID(ctx context.Context, userID in
 	query := `
         SELECT
                 s.id, s.name, s.address, s.price, s.user_id,
-                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                 s.images, s.category_id, s.subcategory_id, s.description,
                 s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude,
                 s.created_at, s.updated_at
@@ -448,7 +448,7 @@ func (r *WorkAdRepository) FetchByStatusAndUserID(ctx context.Context, userID in
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude,
 			&s.CreatedAt, &s.UpdatedAt,
@@ -469,9 +469,9 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-   SELECT DISTINCT
+    SELECT DISTINCT
 
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
            s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
@@ -560,7 +560,7 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
 	for rows.Next() {
 		var s models.FilteredWorkAd
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 			&s.WorkAdID, &s.WorkAdName, &s.WorkAdPrice, &s.WorkAdDescription, &s.WorkAdLatitude, &s.WorkAdLongitude, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
@@ -584,9 +584,9 @@ func (r *WorkAdRepository) GetFilteredWorksAdWithLikes(ctx context.Context, req 
 
 func (r *WorkAdRepository) GetWorkAdByWorkIDAndUserID(ctx context.Context, workadID int, userID int) (models.WorkAd, error) {
 	query := `
-               SELECT
-                       s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+            SELECT
+                    s.id, s.name, s.address, s.price, s.user_id,
+                    u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -608,7 +608,7 @@ func (r *WorkAdRepository) GetWorkAdByWorkIDAndUserID(ctx context.Context, worka
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, workadID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -69,8 +69,8 @@ func (r *WorkRepository) CreateWork(ctx context.Context, work models.Work) (mode
 
 func (r *WorkRepository) GetWorkByID(ctx context.Context, id int, userID int) (models.Work, error) {
 	query := `
-             SELECT w.id, w.name, w.address, w.price, w.user_id,
-                    u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+          SELECT w.id, w.name, w.address, w.price, w.user_id,
+                 u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                     w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked,
                     CASE WHEN sr.id IS NOT NULL THEN true ELSE false END AS responded,
                     w.status, w.work_experience, w.city_id, city.name, city.type, w.schedule, w.distance_work, w.payment_period, w.latitude, w.longitude, w.created_at, w.updated_at
@@ -87,7 +87,7 @@ func (r *WorkRepository) GetWorkByID(ctx context.Context, id int, userID int) (m
 	var imagesJSON []byte
 	err := r.DB.QueryRowContext(ctx, query, userID, id).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName, &s.SubcategoryID, &s.SubcategoryName, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Responded, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.CityType, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 		&s.UpdatedAt,
 	)
@@ -184,9 +184,9 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ci
 
 	baseQuery := `
                SELECT s.id, s.name, s.address, s.price, s.user_id,
-                      u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                      u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                       s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top,
-                     CASE WHEN sf.work_id IS NOT NULL THEN 'true' ELSE 'false' END AS liked,
+                     CASE WHEN sf.work_id IS NOT NULL THEN true ELSE false END AS liked,
                      s.status, s.work_experience, s.city_id, city.name, city.type, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
               FROM work s
               LEFT JOIN work_favorites sf ON sf.work_id = s.id AND sf.user_id = ?
@@ -270,7 +270,7 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ci
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.CityName, &s.CityType, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 			&s.UpdatedAt,
 		)
@@ -304,7 +304,7 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ci
 
 func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]models.Work, error) {
 	query := `
-                SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+             SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
                 FROM work s
                 JOIN users u ON s.user_id = u.id
                 WHERE user_id = ?
@@ -321,7 +321,7 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 		var s models.Work
 		var imagesJSON []byte
 		if err := rows.Scan(
-			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
+			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath, &imagesJSON,
 			&s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude, &s.CreatedAt,
 			&s.UpdatedAt,
 		); err != nil {
@@ -348,9 +348,9 @@ func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]mo
 
 func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.FilterWorkRequest) ([]models.FilteredWork, error) {
 	query := `
-      SELECT
+       SELECT
 
-              u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+               u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
               s.id, s.name, s.price, s.description, s.latitude, s.longitude
       FROM work s
@@ -419,7 +419,7 @@ func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.Fi
 	for rows.Next() {
 		var s models.FilteredWork
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.ServiceLatitude, &s.ServiceLongitude,
 		); err != nil {
 			return nil, err
@@ -438,7 +438,7 @@ func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 	query := `
         SELECT
                 s.id, s.name, s.address, s.price, s.user_id,
-                u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+                u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                 s.images, s.category_id, s.subcategory_id, s.description,
                 s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude,
                 s.created_at, s.updated_at
@@ -458,7 +458,7 @@ func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
 		var imagesJSON []byte
 		err := rows.Scan(
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+			&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID,
 			&s.Description, &s.AvgRating, &s.Top, &s.Liked, &s.Status, &s.WorkExperience, &s.CityID, &s.Schedule, &s.DistanceWork, &s.PaymentPeriod, &s.Latitude, &s.Longitude,
 			&s.CreatedAt, &s.UpdatedAt,
@@ -479,9 +479,9 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 	log.Printf("[INFO] Start GetFilteredServicesWithLikes for user_id=%d", userID)
 
 	query := `
-   SELECT DISTINCT
+    SELECT DISTINCT
 
-           u.id, u.name, u.surname, u.phone, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
+           u.id, u.name, u.surname, COALESCE(u.avatar_path, ''), COALESCE(u.review_rating, 0),
 
            s.id, s.name, s.price, s.description, s.latitude, s.longitude,
            CASE WHEN sf.id IS NOT NULL THEN true ELSE false END AS liked,
@@ -570,7 +570,7 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 	for rows.Next() {
 		var s models.FilteredWork
 		if err := rows.Scan(
-			&s.UserID, &s.UserName, &s.UserSurname, &s.UserPhone, &s.UserAvatarPath, &s.UserRating,
+			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.ServiceLatitude, &s.ServiceLongitude, &s.Liked, &s.Responded,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
@@ -594,9 +594,9 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 
 func (r *WorkRepository) GetWorkByWorkIDAndUserID(ctx context.Context, workID int, userID int) (models.Work, error) {
 	query := `
-               SELECT
-                       s.id, s.name, s.address, s.price, s.user_id,
-                       u.id, u.name, u.surname, u.phone, u.review_rating, u.avatar_path,
+            SELECT
+                    s.id, s.name, s.address, s.price, s.user_id,
+                    u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                        s.images, s.category_id, c.name,
                        s.subcategory_id, sub.name,
                        s.description, s.avg_rating, s.top,
@@ -618,7 +618,7 @@ func (r *WorkRepository) GetWorkByWorkIDAndUserID(ctx context.Context, workID in
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, workID).Scan(
 		&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID,
-		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.Phone, &s.User.ReviewRating, &s.User.AvatarPath,
+		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 		&imagesJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,
 		&s.Description, &s.AvgRating, &s.Top,


### PR DESCRIPTION
## Summary
- stop selecting `u.phone` and scanning phone fields in service, ad, rent, rent ad, work, and work ad repository queries so nullable phones no longer break filtered APIs while the model fields remain intact
- update the aggregated ads query to drop the author phone column and realign scanning with the new column set

## Testing
- go test ./... *(fails: command hung in this environment and was aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c90f20f9e88324be0337e07e67c42e