### PR TITLE
Fix city filtering to use user city

### DIFF
--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -74,7 +74,7 @@ type FilteredAd struct {
 	UserID           int     `json:"user_id"`
 	UserName         string  `json:"user_name"`
 	UserSurname      string  `json:"user_surname"`
-	UserPhone        string  `json:"user_phone"`
+	UserPhone        string  `json:"-"`
 	UserAvatarPath   *string `json:"user_avatar_path,omitempty"`
 	UserRating       float64 `json:"user_rating"`
 	UserReviewsCount int     `json:"user_reviews_count"`

--- a/internal/models/rent.go
+++ b/internal/models/rent.go
@@ -76,7 +76,7 @@ type FilteredRent struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
+	UserPhone          string  `json:"-"`
 	UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
 	UserRating         float64 `json:"user_rating"`
 	UserReviewsCount   int     `json:"user_reviews_count"`

--- a/internal/models/rent_ad.go
+++ b/internal/models/rent_ad.go
@@ -76,7 +76,7 @@ type FilteredRentAd struct {
 	UserID            int     `json:"user_id"`
 	UserName          string  `json:"user_name"`
 	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"user_phone"`
+	UserPhone         string  `json:"-"`
 	UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
 	UserRating        float64 `json:"user_rating"`
 	UserReviewsCount  int     `json:"user_reviews_count"`

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -75,7 +75,7 @@ type FilteredService struct {
 	UserID             int     `json:"user_id"`
 	UserName           string  `json:"user_name"`
 	UserSurname        string  `json:"user_surname"`
-	UserPhone          string  `json:"user_phone"`
+	UserPhone          string  `json:"-"`
 	UserAvatarPath     *string `json:"user_avatar_path,omitempty"`
 	UserRating         float64 `json:"user_rating"`
 	UserReviewsCount   int     `json:"user_reviews_count"`

--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -206,7 +206,7 @@ func (r *AdRepository) GetAdWithFilters(ctx context.Context, userID int, cityID 
 	params = append(params, userID)
 
 	if cityID > 0 {
-		conditions = append(conditions, "s.city_id = ?")
+		conditions = append(conditions, "u.city_id = ?")
 		params = append(params, cityID)
 	}
 
@@ -392,7 +392,7 @@ func (r *AdRepository) GetFilteredAdPost(ctx context.Context, req models.FilterA
 	}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 
@@ -536,7 +536,7 @@ func (r *AdRepository) GetFilteredAdWithLikes(ctx context.Context, req models.Fi
 	}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -203,7 +203,7 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 	params = append(params, userID)
 
 	if cityID > 0 {
-		conditions = append(conditions, "s.city_id = ?")
+		conditions = append(conditions, "u.city_id = ?")
 		params = append(params, cityID)
 	}
 
@@ -278,7 +278,6 @@ func (r *RentAdRepository) GetRentsAdWithFilters(ctx context.Context, userID int
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &likedStr, &s.Status, &s.RentType, &s.Deposit, &s.Latitude, &s.Longitude, &s.CreatedAt, &s.UpdatedAt,
-
 		)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("scan error: %w", err)
@@ -372,7 +371,7 @@ func (r *RentAdRepository) GetFilteredRentsAdPost(ctx context.Context, req model
 	}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 
@@ -508,7 +507,7 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 	}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 
@@ -580,7 +579,6 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
 			&s.RentAdID, &s.RentAdName, &s.RentAdPrice, &s.RentAdDescription, &s.RentAdLatitude, &s.RentAdLongitude, &likedStr, &respondedStr,
-
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -203,7 +203,7 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ci
 	params = append(params, userID)
 
 	if cityID > 0 {
-		conditions = append(conditions, "s.city_id = ?")
+		conditions = append(conditions, "u.city_id = ?")
 		params = append(params, cityID)
 	}
 
@@ -279,7 +279,6 @@ func (r *RentRepository) GetRentsWithFilters(ctx context.Context, userID int, ci
 			&s.ID, &s.Name, &s.Address, &s.Price, &s.UserID, &s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath,
 
 			&imagesJSON, &s.CategoryID, &s.SubcategoryID, &s.Description, &s.AvgRating, &s.Top, &likedStr, &s.Status, &s.RentType, &s.Deposit, &lat, &lon, &s.CreatedAt, &s.UpdatedAt,
-
 		)
 		if err != nil {
 			return nil, 0, 0, fmt.Errorf("scan error: %w", err)
@@ -387,7 +386,7 @@ func (r *RentRepository) GetFilteredRentsPost(ctx context.Context, req models.Fi
 	}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 
@@ -537,7 +536,7 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 	}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 
@@ -610,7 +609,6 @@ func (r *RentRepository) GetFilteredRentsWithLikes(ctx context.Context, req mode
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
 			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon, &likedStr, &respondedStr,
-
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -207,7 +207,7 @@ func (r *ServiceRepository) GetServicesWithFilters(ctx context.Context, userID i
 	params = append(params, userID)
 
 	if cityID > 0 {
-		conditions = append(conditions, "s.city_id = ?")
+		conditions = append(conditions, "u.city_id = ?")
 		params = append(params, cityID)
 	}
 
@@ -395,7 +395,7 @@ func (r *ServiceRepository) GetFilteredServicesPost(ctx context.Context, req mod
 	}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 
@@ -546,7 +546,7 @@ func (r *ServiceRepository) GetFilteredServicesWithLikes(ctx context.Context, re
 	}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -73,12 +73,12 @@ func (r *WorkRepository) GetWorkByID(ctx context.Context, id int, userID int) (m
                  u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                     w.images, w.category_id, c.name, w.subcategory_id, sub.name, w.description, w.avg_rating, w.top, w.liked,
                     CASE WHEN sr.id IS NOT NULL THEN '1' ELSE '0' END AS responded,
-                    w.status, w.work_experience, w.city_id, city.name, city.type, w.schedule, w.distance_work, w.payment_period, w.latitude, w.longitude, w.created_at, w.updated_at
+                    w.status, w.work_experience, u.city_id, city.name, city.type, w.schedule, w.distance_work, w.payment_period, w.latitude, w.longitude, w.created_at, w.updated_at
               FROM work w
               JOIN users u ON w.user_id = u.id
               JOIN work_categories c ON w.category_id = c.id
               JOIN work_subcategories sub ON w.subcategory_id = sub.id
-              JOIN cities city ON w.city_id = city.id
+              JOIN cities city ON u.city_id = city.id
               LEFT JOIN work_responses sr ON sr.work_id = w.id AND sr.user_id = ?
               WHERE w.id = ?
        `
@@ -195,18 +195,18 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ci
 
                      CASE WHEN sf.work_id IS NOT NULL THEN '1' ELSE '0' END AS liked,
 
-                     s.status, s.work_experience, s.city_id, city.name, city.type, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+                     s.status, s.work_experience, u.city_id, city.name, city.type, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
               FROM work s
               LEFT JOIN work_favorites sf ON sf.work_id = s.id AND sf.user_id = ?
               JOIN users u ON s.user_id = u.id
               INNER JOIN work_categories c ON s.category_id = c.id
-              JOIN cities city ON s.city_id = city.id
+              JOIN cities city ON u.city_id = city.id
 
        `
 	params = append(params, userID)
 
 	if cityID > 0 {
-		conditions = append(conditions, "s.city_id = ?")
+		conditions = append(conditions, "u.city_id = ?")
 		params = append(params, cityID)
 	}
 
@@ -317,7 +317,7 @@ func (r *WorkRepository) GetWorksWithFilters(ctx context.Context, userID int, ci
 
 func (r *WorkRepository) GetWorksByUserID(ctx context.Context, userID int) ([]models.Work, error) {
 	query := `
-             SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+             SELECT s.id, s.name, s.address, s.price, s.user_id, u.id, u.name, u.surname, u.review_rating, u.avatar_path, s.images, s.category_id, s.subcategory_id, s.description, s.avg_rating, s.top, s.liked, s.status, s.work_experience, u.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
                 FROM work s
                 JOIN users u ON s.user_id = u.id
                 WHERE user_id = ?
@@ -373,7 +373,7 @@ func (r *WorkRepository) GetFilteredWorksPost(ctx context.Context, req models.Fi
 	args := []interface{}{}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 
@@ -453,7 +453,7 @@ func (r *WorkRepository) FetchByStatusAndUserID(ctx context.Context, userID int,
                 s.id, s.name, s.address, s.price, s.user_id,
                 u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                 s.images, s.category_id, s.subcategory_id, s.description,
-                s.avg_rating, s.top, s.liked, s.status, s.work_experience, s.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude,
+                s.avg_rating, s.top, s.liked, s.status, s.work_experience, u.city_id, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude,
                 s.created_at, s.updated_at
         FROM work s
         JOIN users u ON s.user_id = u.id
@@ -509,7 +509,7 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 	args := []interface{}{userID, userID}
 
 	if req.CityID > 0 {
-		query += " AND s.city_id = ?"
+		query += " AND u.city_id = ?"
 		args = append(args, req.CityID)
 	}
 
@@ -587,7 +587,6 @@ func (r *WorkRepository) GetFilteredWorksWithLikes(ctx context.Context, req mode
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
 			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &s.ServiceLatitude, &s.ServiceLongitude, &likedStr, &respondedStr,
-
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)
@@ -620,12 +619,12 @@ func (r *WorkRepository) GetWorkByWorkIDAndUserID(ctx context.Context, workID in
                        s.description, s.avg_rating, s.top,
               CASE WHEN sf.id IS NOT NULL THEN '1' ELSE '0' END AS liked,
               CASE WHEN sr.id IS NOT NULL THEN '1' ELSE '0' END AS responded,
-              s.status, s.work_experience, s.city_id, city.name, city.type, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
+              s.status, s.work_experience, u.city_id, city.name, city.type, s.schedule, s.distance_work, s.payment_period, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM work s
                JOIN users u ON s.user_id = u.id
                JOIN work_categories c ON s.category_id = c.id
                JOIN work_subcategories sub ON s.subcategory_id = sub.id
-               JOIN cities city ON s.city_id = city.id
+               JOIN cities city ON u.city_id = city.id
                LEFT JOIN work_favorites sf ON sf.work_id = s.id AND sf.user_id = ?
                LEFT JOIN work_responses sr ON sr.work_id = s.id AND sr.user_id = ?
                WHERE s.id = ?


### PR DESCRIPTION
## Summary
- fix service filtering queries to reference the executor's city stored on the users table instead of the non-existent city column on services
- apply the same city filter fix to ad, rent, and rent ad queries so they reference the users table
- extend work and work ad queries to rely on the executor's city_id from users for all filtering and detail endpoints, and stop exposing user phone fields in filtered responses

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68c97c2ec90c8324b5e82677b62f56f8