### PR TITLE
Deduct responses when clients reply to executors

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -223,7 +223,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	rentFavoriteService := &services.RentFavoriteService{RentFavoriteRepo: &rentFavoriteRepo}
 	adService := &services.AdService{AdRepo: &adRepo}
 	adReviewService := &services.AdReviewService{AdReviewsRepo: &adReviewRepo}
-	adResponseService := &services.AdResponseService{AdResponseRepo: &adResponseRepo, AdRepo: &adRepo, ChatRepo: &chatRepo, ConfirmationRepo: &adConfirmationRepo, MessageRepo: &messageRepo}
+	adResponseService := &services.AdResponseService{AdResponseRepo: &adResponseRepo, AdRepo: &adRepo, ChatRepo: &chatRepo, ConfirmationRepo: &adConfirmationRepo, MessageRepo: &messageRepo, SubscriptionRepo: &subscriptionRepo}
 	adFavoriteService := &services.AdFavoriteService{AdFavoriteRepo: &adFavoriteRepo}
 	subscriptionService := &services.SubscriptionService{Repo: &subscriptionRepo}
 	locationService := &services.LocationService{Repo: &locationRepo}
@@ -240,11 +240,11 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 
 	workAdService := &services.WorkAdService{WorkAdRepo: &workAdRepo}
 	workAdReviewService := &services.WorkAdReviewService{WorkAdReviewsRepo: &workAdReviewRepo}
-	workAdResponseService := &services.WorkAdResponseService{WorkAdResponseRepo: &workAdResponseRepo, WorkAdRepo: &workAdRepo, ChatRepo: &chatRepo, ConfirmationRepo: &workAdConfirmationRepo, MessageRepo: &messageRepo}
+	workAdResponseService := &services.WorkAdResponseService{WorkAdResponseRepo: &workAdResponseRepo, WorkAdRepo: &workAdRepo, ChatRepo: &chatRepo, ConfirmationRepo: &workAdConfirmationRepo, MessageRepo: &messageRepo, SubscriptionRepo: &subscriptionRepo}
 	workAdFavoriteService := &services.WorkAdFavoriteService{WorkAdFavoriteRepo: &workAdFavoriteRepo}
 	rentAdService := &services.RentAdService{RentAdRepo: &rentAdRepo}
 	rentAdReviewService := &services.RentAdReviewService{RentAdReviewsRepo: &rentAdReviewRepo}
-	rentAdResponseService := &services.RentAdResponseService{RentAdResponseRepo: &rentAdResponseRepo, RentAdRepo: &rentAdRepo, ChatRepo: &chatRepo, ConfirmationRepo: &rentAdConfirmationRepo, MessageRepo: &messageRepo}
+	rentAdResponseService := &services.RentAdResponseService{RentAdResponseRepo: &rentAdResponseRepo, RentAdRepo: &rentAdRepo, ChatRepo: &chatRepo, ConfirmationRepo: &rentAdConfirmationRepo, MessageRepo: &messageRepo, SubscriptionRepo: &subscriptionRepo}
 	rentAdFavoriteService := &services.RentAdFavoriteService{RentAdFavoriteRepo: &rentAdFavoriteRepo}
 	adConfirmationService := &services.AdConfirmationService{ConfirmationRepo: &adConfirmationRepo}
 	workConfirmationService := &services.WorkConfirmationService{ConfirmationRepo: &workConfirmationRepo}

--- a/internal/handlers/ad_responses_handler.go
+++ b/internal/handlers/ad_responses_handler.go
@@ -25,9 +25,11 @@ func (h *AdResponseHandler) CreateAdResponse(w http.ResponseWriter, r *http.Requ
 	resp, err := h.Service.CreateAdResponse(r.Context(), input)
 	if err != nil {
 		if errors.Is(err, models.ErrAlreadyResponded) {
-
 			http.Error(w, "already responded", http.StatusOK)
-
+			return
+		}
+		if errors.Is(err, models.ErrNoRemainingResponses) {
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 		http.Error(w, "Could not create response", http.StatusInternalServerError)

--- a/internal/handlers/rent_ad_responses_handler.go
+++ b/internal/handlers/rent_ad_responses_handler.go
@@ -25,9 +25,11 @@ func (h *RentAdResponseHandler) CreateRentAdResponse(w http.ResponseWriter, r *h
 	resp, err := h.Service.CreateRentAdResponse(r.Context(), input)
 	if err != nil {
 		if errors.Is(err, models.ErrAlreadyResponded) {
-
 			http.Error(w, "already responded", http.StatusOK)
-
+			return
+		}
+		if errors.Is(err, models.ErrNoRemainingResponses) {
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 		http.Error(w, "Could not create response", http.StatusInternalServerError)

--- a/internal/handlers/work_ad_responses_handler.go
+++ b/internal/handlers/work_ad_responses_handler.go
@@ -25,9 +25,11 @@ func (h *WorkAdResponseHandler) CreateWorkAdResponse(w http.ResponseWriter, r *h
 	resp, err := h.Service.CreateWorkAdResponse(r.Context(), input)
 	if err != nil {
 		if errors.Is(err, models.ErrAlreadyResponded) {
-
 			http.Error(w, "already responded", http.StatusOK)
-
+			return
+		}
+		if errors.Is(err, models.ErrNoRemainingResponses) {
+			http.Error(w, err.Error(), http.StatusForbidden)
 			return
 		}
 		http.Error(w, "Could not create response", http.StatusInternalServerError)

--- a/internal/models/errors.go
+++ b/internal/models/errors.go
@@ -31,6 +31,7 @@ var (
 	ErrReviewNotFound         = errors.New("review not found")
 	ErrSubcategoryNotFound    = errors.New("subcategory not found")
 	ErrAlreadyResponded       = errors.New("user already responded")
+	ErrNoRemainingResponses   = errors.New("no remaining responses")
 )
 
 var ErrInvalidVerificationCode = errors.New("invalid verification code")

--- a/internal/repositories/ad_responses_repository.go
+++ b/internal/repositories/ad_responses_repository.go
@@ -41,3 +41,8 @@ func (r *AdResponseRepository) CreateAdResponse(ctx context.Context, resp models
 
 	return resp, nil
 }
+
+func (r *AdResponseRepository) DeleteResponse(ctx context.Context, id int) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM ad_responses WHERE id = ?`, id)
+	return err
+}

--- a/internal/repositories/rent_ad_responses_repository.go
+++ b/internal/repositories/rent_ad_responses_repository.go
@@ -41,3 +41,8 @@ func (r *RentAdResponseRepository) CreateRentAdResponse(ctx context.Context, res
 
 	return resp, nil
 }
+
+func (r *RentAdResponseRepository) DeleteResponse(ctx context.Context, id int) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM rent_ad_responses WHERE id = ?`, id)
+	return err
+}

--- a/internal/repositories/subscription_repository.go
+++ b/internal/repositories/subscription_repository.go
@@ -50,3 +50,23 @@ func (r *SubscriptionRepository) HasActiveSubscription(ctx context.Context, user
 	}
 	return count > 0, nil
 }
+
+func (r *SubscriptionRepository) ConsumeResponse(ctx context.Context, userID int) error {
+	res, err := r.DB.ExecContext(ctx, `UPDATE subscription_responses SET remaining = remaining - 1 WHERE user_id = ? AND remaining > 0`, userID)
+	if err != nil {
+		return err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affected == 0 {
+		return models.ErrNoRemainingResponses
+	}
+	return nil
+}
+
+func (r *SubscriptionRepository) RestoreResponse(ctx context.Context, userID int) error {
+	_, err := r.DB.ExecContext(ctx, `UPDATE subscription_responses SET remaining = remaining + 1 WHERE user_id = ?`, userID)
+	return err
+}

--- a/internal/repositories/work_ad_responses_repository.go
+++ b/internal/repositories/work_ad_responses_repository.go
@@ -41,3 +41,8 @@ func (r *WorkAdResponseRepository) CreateWorkAdResponse(ctx context.Context, res
 
 	return resp, nil
 }
+
+func (r *WorkAdResponseRepository) DeleteResponse(ctx context.Context, id int) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM work_ad_responses WHERE id = ?`, id)
+	return err
+}


### PR DESCRIPTION
## Summary
- decrement subscription response balances when clients create ad, work ad, or rent ad responses
- surface an error when no responses remain and return HTTP 403 from the response endpoints
- wire the subscription repository into the response services so balances are restored on failures

## Testing
- `go test ./...` *(hangs locally, manually aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a7ec4e788324ad630225ab1a7d1a