### PR TITLE
Send registration verification codes via email

### DIFF
--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -437,6 +437,11 @@ func (h *UserHandler) CheckUserDuplicate(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if strings.TrimSpace(req.Email) == "" {
+		http.Error(w, "email обязателен", http.StatusBadRequest)
+		return
+	}
+
 	duplicate, err := h.Service.CheckUserDuplicate(r.Context(), req)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -448,7 +453,7 @@ func (h *UserHandler) CheckUserDuplicate(w http.ResponseWriter, r *http.Request)
 	if duplicate {
 		resp["message"] = "номер телефона или email уже зарегистрирован"
 	} else {
-		resp["message"] = "Код отправлен на номер"
+		resp["message"] = "Код отправлен на email"
 	}
 	json.NewEncoder(w).Encode(resp)
 }


### PR DESCRIPTION
## Summary
- require an email in the duplicate check handler and adjust the success message to reference email delivery
- switch duplicate checks in the user service to send verification codes via SMTP email and persist codes by email instead of SMS/phone

## Testing
- `go test ./...` *(hangs; command aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc074509883249481dc158bff524c