### PR TITLE
Add video support for services

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -73,6 +73,7 @@ func (app *application) routes() http.Handler {
 	mux.Post("/service/cancel", authMiddleware.ThenFunc(app.serviceConfirmationHandler.CancelService))
 	mux.Post("/service/done", authMiddleware.ThenFunc(app.serviceConfirmationHandler.DoneService))
 	mux.Get("/images/services/:filename", http.HandlerFunc(app.serviceHandler.ServeServiceImage))
+	mux.Get("/videos/services/:filename", http.HandlerFunc(app.serviceHandler.ServeServiceVideo))
 	mux.Post("/service/filtered/:user_id", authMiddleware.ThenFunc(app.serviceHandler.GetFilteredServicesWithLikes))
 	mux.Get("/service/service_id/:service_id/user/:user_id", standardMiddleware.ThenFunc(app.serviceHandler.GetServiceByServiceIDAndUserID))
 

--- a/db/migrations/000064_service_videos.down.sql
+++ b/db/migrations/000064_service_videos.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE service
+    DROP COLUMN videos;

--- a/db/migrations/000064_service_videos.up.sql
+++ b/db/migrations/000064_service_videos.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE service
+    ADD COLUMN videos TEXT AFTER images;
+use naimudb;

--- a/internal/handlers/image_utils.go
+++ b/internal/handlers/image_utils.go
@@ -11,7 +11,7 @@ import (
 
 // imagePayload объединяет все типы изображений, используемых в сущностях.
 type imagePayload interface {
-	models.Image | models.ImageAd | models.ImageRent | models.ImageRentAd | models.ImageWork | models.ImageWorkAd
+	models.Image | models.ImageAd | models.ImageRent | models.ImageRentAd | models.ImageWork | models.ImageWorkAd | models.Video
 }
 
 // collectImageFiles собирает все файлы по указанным ключам формы.
@@ -118,6 +118,10 @@ func normalizeImage[T imagePayload](img *T) {
 		if v.Name == "" {
 			v.Name = v.Path
 		}
+	case *models.Video:
+		if v.Name == "" {
+			v.Name = v.Path
+		}
 	}
 }
 
@@ -146,6 +150,10 @@ func newLinkImage[T imagePayload](path string) T {
 		v.Path = path
 		v.Type = "link"
 	case *models.ImageWorkAd:
+		v.Name = path
+		v.Path = path
+		v.Type = "link"
+	case *models.Video:
 		v.Name = path
 		v.Path = path
 		v.Type = "link"

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -331,6 +331,39 @@ func (h *ServiceHandler) ServeServiceImage(w http.ResponseWriter, r *http.Reques
 	http.ServeFile(w, r, imagePath)
 }
 
+func (h *ServiceHandler) ServeServiceVideo(w http.ResponseWriter, r *http.Request) {
+	filename := r.URL.Query().Get(":filename")
+	if filename == "" {
+		http.Error(w, "filename is required", http.StatusBadRequest)
+		return
+	}
+
+	videoPath := filepath.Join("cmd/uploads/services/videos", filename)
+
+	if _, err := os.Stat(videoPath); os.IsNotExist(err) {
+		http.Error(w, "video not found", http.StatusNotFound)
+		return
+	}
+
+	ext := strings.ToLower(filepath.Ext(videoPath))
+	var contentType string
+	switch ext {
+	case ".mp4":
+		contentType = "video/mp4"
+	case ".mov":
+		contentType = "video/quicktime"
+	case ".webm":
+		contentType = "video/webm"
+	case ".mkv":
+		contentType = "video/x-matroska"
+	default:
+		contentType = "application/octet-stream"
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	http.ServeFile(w, r, videoPath)
+}
+
 func (h *ServiceHandler) CreateService(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseMultipartForm(32 << 20) // 32MB
 	if err != nil {
@@ -401,6 +434,57 @@ func (h *ServiceHandler) CreateService(w http.ResponseWriter, r *http.Request) {
 	}
 
 	service.Images = imageInfos
+
+	videoDir := "cmd/uploads/services/videos"
+	if err := os.MkdirAll(videoDir, 0755); err != nil {
+		http.Error(w, "Failed to create video directory", http.StatusInternalServerError)
+		return
+	}
+
+	videoHeaders := collectImageFiles(r.MultipartForm, "videos", "videos[]")
+	var videoInfos []models.Video
+
+	for _, fileHeader := range videoHeaders {
+		file, err := fileHeader.Open()
+		if err != nil {
+			http.Error(w, "Failed to open video", http.StatusInternalServerError)
+			return
+		}
+		defer file.Close()
+
+		timestamp := time.Now().UnixNano()
+		ext := filepath.Ext(fileHeader.Filename)
+		videoName := fmt.Sprintf("service_video_%d%s", timestamp, ext)
+		savePath := filepath.Join(videoDir, videoName)
+		publicURL := fmt.Sprintf("/videos/services/%s", videoName)
+
+		dst, err := os.Create(savePath)
+		if err != nil {
+			http.Error(w, "Cannot save video", http.StatusInternalServerError)
+			return
+		}
+		defer dst.Close()
+
+		if _, err := io.Copy(dst, file); err != nil {
+			http.Error(w, "Failed to write video", http.StatusInternalServerError)
+			return
+		}
+
+		videoInfos = append(videoInfos, models.Video{
+			Name: fileHeader.Filename,
+			Path: publicURL,
+			Type: fileHeader.Header.Get("Content-Type"),
+		})
+	}
+
+	if parsedLinks, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "video_links", "video_links[]"); err != nil {
+		http.Error(w, "Invalid video links payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videoInfos = append(videoInfos, parsedLinks...)
+	}
+
+	service.Videos = videoInfos
 
 	createdService, err := h.Service.CreateService(r.Context(), service)
 	if err != nil {
@@ -554,6 +638,73 @@ func (h *ServiceHandler) UpdateService(w http.ResponseWriter, r *http.Request) {
 	}
 
 	service.Images = images
+
+	videos := service.Videos
+
+	if parsedVideos, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "videos", "videos[]"); err != nil {
+		http.Error(w, "Invalid videos payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videos = parsedVideos
+	} else if parsedExisting, okExisting, err := gatherImagesFromForm[models.Video](r.MultipartForm, "existing_videos", "existing_videos[]"); err != nil {
+		http.Error(w, "Invalid videos payload", http.StatusBadRequest)
+		return
+	} else if okExisting {
+		videos = parsedExisting
+	}
+
+	if parsedLinks, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "video_links", "video_links[]"); err != nil {
+		http.Error(w, "Invalid video links payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videos = append(videos, parsedLinks...)
+	}
+
+	videoDir := "cmd/uploads/services/videos"
+	if err := os.MkdirAll(videoDir, 0755); err != nil {
+		http.Error(w, "Failed to create video directory", http.StatusInternalServerError)
+		return
+	}
+
+	videoHeaders := collectImageFiles(r.MultipartForm, "videos", "videos[]")
+	if len(videoHeaders) > 0 {
+		var uploaded []models.Video
+		for _, fileHeader := range videoHeaders {
+			file, err := fileHeader.Open()
+			if err != nil {
+				http.Error(w, "Failed to open video", http.StatusInternalServerError)
+				return
+			}
+			defer file.Close()
+
+			timestamp := time.Now().UnixNano()
+			ext := filepath.Ext(fileHeader.Filename)
+			videoName := fmt.Sprintf("service_video_%d%s", timestamp, ext)
+			savePath := filepath.Join(videoDir, videoName)
+			publicURL := fmt.Sprintf("/videos/services/%s", videoName)
+
+			dst, err := os.Create(savePath)
+			if err != nil {
+				http.Error(w, "Cannot save video", http.StatusInternalServerError)
+				return
+			}
+			defer dst.Close()
+
+			if _, err := io.Copy(dst, file); err != nil {
+				http.Error(w, "Failed to write video", http.StatusInternalServerError)
+				return
+			}
+
+			uploaded = append(uploaded, models.Video{
+				Name: fileHeader.Filename,
+				Path: publicURL,
+				Type: fileHeader.Header.Get("Content-Type"),
+			})
+		}
+		videos = append(videos, uploaded...)
+	}
+
+	service.Videos = videos
 
 	now := time.Now()
 	service.UpdatedAt = &now

--- a/internal/models/service.go
+++ b/internal/models/service.go
@@ -20,6 +20,7 @@ type Service struct {
 		AvatarPath   *string `json:"avatar_path,omitempty"`
 	} `json:"user"`
 	Images          []Image    `json:"images"`
+	Videos          []Video    `json:"videos"`
 	CategoryID      int        `json:"category_id, omitempty"`
 	SubcategoryID   int        `json:"subcategory_id, omitempty"`
 	Description     string     `json:"description"`
@@ -38,6 +39,12 @@ type Service struct {
 }
 
 type Image struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
+	Type string `json:"type"`
+}
+
+type Video struct {
 	Name string `json:"name"`
 	Path string `json:"path"`
 	Type string `json:"type"`


### PR DESCRIPTION
## Summary
- allow service creation and editing to upload and link video files alongside images
- persist service video metadata and expose it through repository queries and API responses
- add a database migration and HTTP route for serving stored service videos

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd7df421108324b24e957681f5a866