### PR TITLE
Fix user ID handling in service creation

### DIFF
--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -375,7 +375,23 @@ func (h *ServiceHandler) CreateService(w http.ResponseWriter, r *http.Request) {
 	service.Name = r.FormValue("name")
 	service.Address = r.FormValue("address")
 	service.Price, _ = strconv.ParseFloat(r.FormValue("price"), 64)
-	service.UserID, _ = strconv.Atoi(r.FormValue("user_id"))
+	if userIDStr := r.FormValue("user_id"); userIDStr != "" {
+		userID, err := strconv.Atoi(userIDStr)
+		if err != nil {
+			http.Error(w, "Invalid user_id", http.StatusBadRequest)
+			return
+		}
+		service.UserID = userID
+	}
+	if service.UserID == 0 {
+		if ctxUserID, ok := r.Context().Value("user_id").(int); ok && ctxUserID != 0 {
+			service.UserID = ctxUserID
+		}
+	}
+	if service.UserID == 0 {
+		http.Error(w, "Missing user_id", http.StatusBadRequest)
+		return
+	}
 	service.Description = r.FormValue("description")
 	service.CategoryID, _ = strconv.Atoi(r.FormValue("category_id"))
 	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))


### PR DESCRIPTION
## Summary
- ensure the service creation handler reads the user ID from the authenticated request context when the form field is missing
- validate the provided user_id form value before using it so invalid data returns a clear error

## Testing
- `go test ./...` *(fails: command hung because the tests require external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8b04c5d083248dca26a6656f8347