### PR TITLE
Handle malformed media payloads gracefully

### DIFF
--- a/internal/handlers/image_utils_test.go
+++ b/internal/handlers/image_utils_test.go
@@ -1,0 +1,67 @@
+package handlers
+
+import (
+	"mime/multipart"
+	"testing"
+
+	"naimuBack/internal/models"
+)
+
+func TestParseImagesFromValuesSkipsInvalid(t *testing.T) {
+	values := []string{"[object Object]", "{not json}", "\"/static/video.mp4\"", "https://cdn.example.com/image.jpg"}
+
+	videos, err := parseImagesFromValues[models.Video](values)
+	if err != nil {
+		t.Fatalf("parseImagesFromValues returned error: %v", err)
+	}
+
+	if len(videos) != 2 {
+		t.Fatalf("expected 2 parsed entries, got %d", len(videos))
+	}
+
+	if videos[0].Path != "/static/video.mp4" {
+		t.Errorf("expected first video path to be unquoted, got %q", videos[0].Path)
+	}
+
+	if videos[1].Path != "https://cdn.example.com/image.jpg" {
+		t.Errorf("unexpected second video path: %q", videos[1].Path)
+	}
+}
+
+func TestParseImagesFromValuesArrayOfStrings(t *testing.T) {
+	values := []string{"[\"/a.jpg\",\"/b.jpg\"]"}
+
+	images, err := parseImagesFromValues[models.Image](values)
+	if err != nil {
+		t.Fatalf("parseImagesFromValues returned error: %v", err)
+	}
+
+	if len(images) != 2 {
+		t.Fatalf("expected 2 images, got %d", len(images))
+	}
+
+	if images[0].Path != "/a.jpg" || images[1].Path != "/b.jpg" {
+		t.Fatalf("unexpected image paths: %#v", images)
+	}
+}
+
+func TestGatherImagesFromFormInvalidValuesIgnored(t *testing.T) {
+	form := &multipart.Form{
+		Value: map[string][]string{
+			"videos": []string{"[object Object]", ""},
+		},
+	}
+
+	videos, ok, err := gatherImagesFromForm[models.Video](form, "videos")
+	if err != nil {
+		t.Fatalf("gatherImagesFromForm returned error: %v", err)
+	}
+
+	if ok {
+		t.Fatalf("expected ok to be false when no valid payloads are found")
+	}
+
+	if len(videos) != 0 {
+		t.Fatalf("expected zero videos, got %d", len(videos))
+	}
+}

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -413,10 +413,24 @@ func (h *ServiceHandler) CreateService(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	files := r.MultipartForm.File["images"]
+	imageHeaders := collectImageFiles(r.MultipartForm, "images", "images[]")
 	var imageInfos []models.Image
 
-	for _, fileHeader := range files {
+	if parsedImages, ok, err := gatherImagesFromForm[models.Image](r.MultipartForm, "images", "images[]"); err != nil {
+		http.Error(w, "Invalid images payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		imageInfos = append(imageInfos, parsedImages...)
+	}
+
+	if parsedLinks, ok, err := gatherImagesFromForm[models.Image](r.MultipartForm, "image_links", "image_links[]"); err != nil {
+		http.Error(w, "Invalid image links payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		imageInfos = append(imageInfos, parsedLinks...)
+	}
+
+	for _, fileHeader := range imageHeaders {
 		file, err := fileHeader.Open()
 		if err != nil {
 			http.Error(w, "Failed to open image", http.StatusInternalServerError)
@@ -459,6 +473,13 @@ func (h *ServiceHandler) CreateService(w http.ResponseWriter, r *http.Request) {
 
 	videoHeaders := collectImageFiles(r.MultipartForm, "videos", "videos[]")
 	var videoInfos []models.Video
+
+	if parsedVideos, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "videos", "videos[]"); err != nil {
+		http.Error(w, "Invalid videos payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videoInfos = append(videoInfos, parsedVideos...)
+	}
 
 	for _, fileHeader := range videoHeaders {
 		file, err := fileHeader.Open()


### PR DESCRIPTION
## Summary
- relax media payload parsing so malformed JSON snippets are ignored instead of returning HTTP 400
- support arrays of string links and quoted paths when collecting media values
- add unit tests covering invalid payload skipping and new string-array handling

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cd91ff84948324affb98e73b35ab36