### PR TITLE
Align Rent and Work video handling with Service

### DIFF
--- a/internal/handlers/rent_handler.go
+++ b/internal/handlers/rent_handler.go
@@ -441,6 +441,13 @@ func (h *RentHandler) CreateRent(w http.ResponseWriter, r *http.Request) {
 	videoHeaders := collectImageFiles(r.MultipartForm, "videos", "videos[]")
 	var videoInfos []models.Video
 
+	if parsedVideos, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "videos", "videos[]"); err != nil {
+		http.Error(w, "Invalid videos payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videoInfos = append(videoInfos, parsedVideos...)
+	}
+
 	for _, fileHeader := range videoHeaders {
 		file, err := fileHeader.Open()
 		if err != nil {

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -456,6 +456,13 @@ func (h *WorkHandler) CreateWork(w http.ResponseWriter, r *http.Request) {
 	videoHeaders := collectImageFiles(r.MultipartForm, "videos", "videos[]")
 	var videoInfos []models.Video
 
+	if parsedVideos, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "videos", "videos[]"); err != nil {
+		http.Error(w, "Invalid videos payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videoInfos = append(videoInfos, parsedVideos...)
+	}
+
 	for _, fileHeader := range videoHeaders {
 		file, err := fileHeader.Open()
 		if err != nil {


### PR DESCRIPTION
## Summary
- allow Rent and Work create handlers to parse structured video payloads before processing uploads
- align video link handling for Rent and Work with the logic already used in Service handlers

## Testing
- go test ./... *(fails: command hung, likely waiting on external dependencies; interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68ce960c40a08324b55527f11b60ee49