### PR TITLE
Add video support to ads

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -290,6 +290,7 @@ func (app *application) routes() http.Handler {
 	mux.Post("/ad/cancel", authMiddleware.ThenFunc(app.adConfirmationHandler.CancelAd))
 	mux.Post("/ad/done", authMiddleware.ThenFunc(app.adConfirmationHandler.DoneAd))
 	mux.Get("/images/ad/:filename", http.HandlerFunc(app.adHandler.ServeAdImage))
+	mux.Get("/videos/ad/:filename", http.HandlerFunc(app.adHandler.ServeAdVideo))
 	mux.Post("/ad/filtered/:user_id", authMiddleware.ThenFunc(app.adHandler.GetFilteredAdWithLikes))
 	mux.Get("/ad/ad_id/:ad_id/user/:user_id", standardMiddleware.ThenFunc(app.adHandler.GetAdByAdIDAndUserID))
 

--- a/db/migrations/000067_ad_videos.down.sql
+++ b/db/migrations/000067_ad_videos.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ad
+    DROP COLUMN videos;

--- a/db/migrations/000067_ad_videos.up.sql
+++ b/db/migrations/000067_ad_videos.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE ad
+    ADD COLUMN videos TEXT AFTER images;
+use naimudb;

--- a/internal/handlers/ad_handler.go
+++ b/internal/handlers/ad_handler.go
@@ -330,6 +330,36 @@ func (h *AdHandler) ServeAdImage(w http.ResponseWriter, r *http.Request) {
 	http.ServeFile(w, r, imagePath)
 }
 
+func (h *AdHandler) ServeAdVideo(w http.ResponseWriter, r *http.Request) {
+	filename := r.URL.Query().Get(":filename")
+	if filename == "" {
+		http.Error(w, "filename is required", http.StatusBadRequest)
+		return
+	}
+
+	videoPath := filepath.Join("cmd/uploads/ad/videos", filename)
+	if _, err := os.Stat(videoPath); os.IsNotExist(err) {
+		http.Error(w, "video not found", http.StatusNotFound)
+		return
+	}
+
+	ext := strings.ToLower(filepath.Ext(videoPath))
+	contentType := "application/octet-stream"
+	switch ext {
+	case ".mp4":
+		contentType = "video/mp4"
+	case ".mov":
+		contentType = "video/quicktime"
+	case ".webm":
+		contentType = "video/webm"
+	case ".mkv":
+		contentType = "video/x-matroska"
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	http.ServeFile(w, r, videoPath)
+}
+
 func (h *AdHandler) CreateAd(w http.ResponseWriter, r *http.Request) {
 	err := r.ParseMultipartForm(32 << 20) // 32MB
 	if err != nil {
@@ -394,6 +424,64 @@ func (h *AdHandler) CreateAd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	service.Images = imageInfos
+
+	videoDir := "cmd/uploads/ad/videos"
+	if err := os.MkdirAll(videoDir, 0755); err != nil {
+		http.Error(w, "Failed to create video directory", http.StatusInternalServerError)
+		return
+	}
+
+	videoHeaders := collectImageFiles(r.MultipartForm, "videos", "videos[]")
+	var videoInfos []models.Video
+
+	if parsedVideos, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "videos", "videos[]"); err != nil {
+		http.Error(w, "Invalid videos payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videoInfos = append(videoInfos, parsedVideos...)
+	}
+
+	for _, fileHeader := range videoHeaders {
+		file, err := fileHeader.Open()
+		if err != nil {
+			http.Error(w, "Failed to open video", http.StatusInternalServerError)
+			return
+		}
+		defer file.Close()
+
+		timestamp := time.Now().UnixNano()
+		ext := filepath.Ext(fileHeader.Filename)
+		videoName := fmt.Sprintf("ad_video_%d%s", timestamp, ext)
+		savePath := filepath.Join(videoDir, videoName)
+		publicURL := fmt.Sprintf("/videos/ad/%s", videoName)
+
+		dst, err := os.Create(savePath)
+		if err != nil {
+			http.Error(w, "Cannot save video", http.StatusInternalServerError)
+			return
+		}
+		defer dst.Close()
+
+		if _, err := io.Copy(dst, file); err != nil {
+			http.Error(w, "Failed to write video", http.StatusInternalServerError)
+			return
+		}
+
+		videoInfos = append(videoInfos, models.Video{
+			Name: fileHeader.Filename,
+			Path: publicURL,
+			Type: fileHeader.Header.Get("Content-Type"),
+		})
+	}
+
+	if parsedLinks, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "video_links", "video_links[]"); err != nil {
+		http.Error(w, "Invalid video links payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videoInfos = append(videoInfos, parsedLinks...)
+	}
+
+	service.Videos = videoInfos
 
 	createdService, err := h.Service.CreateAd(r.Context(), service)
 	if err != nil {
@@ -542,6 +630,73 @@ func (h *AdHandler) UpdateAd(w http.ResponseWriter, r *http.Request) {
 	}
 
 	service.Images = images
+
+	videos := service.Videos
+
+	if parsedVideos, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "videos", "videos[]"); err != nil {
+		http.Error(w, "Invalid videos payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videos = parsedVideos
+	} else if parsedExisting, okExisting, err := gatherImagesFromForm[models.Video](r.MultipartForm, "existing_videos", "existing_videos[]"); err != nil {
+		http.Error(w, "Invalid videos payload", http.StatusBadRequest)
+		return
+	} else if okExisting {
+		videos = parsedExisting
+	}
+
+	if parsedLinks, ok, err := gatherImagesFromForm[models.Video](r.MultipartForm, "video_links", "video_links[]"); err != nil {
+		http.Error(w, "Invalid video links payload", http.StatusBadRequest)
+		return
+	} else if ok {
+		videos = append(videos, parsedLinks...)
+	}
+
+	videoDir := "cmd/uploads/ad/videos"
+	if err := os.MkdirAll(videoDir, 0755); err != nil {
+		http.Error(w, "Failed to create video directory", http.StatusInternalServerError)
+		return
+	}
+
+	videoHeaders := collectImageFiles(r.MultipartForm, "videos", "videos[]")
+	if len(videoHeaders) > 0 {
+		var uploaded []models.Video
+		for _, fileHeader := range videoHeaders {
+			file, err := fileHeader.Open()
+			if err != nil {
+				http.Error(w, "Failed to open video", http.StatusInternalServerError)
+				return
+			}
+			defer file.Close()
+
+			timestamp := time.Now().UnixNano()
+			ext := filepath.Ext(fileHeader.Filename)
+			videoName := fmt.Sprintf("ad_video_%d%s", timestamp, ext)
+			savePath := filepath.Join(videoDir, videoName)
+			publicURL := fmt.Sprintf("/videos/ad/%s", videoName)
+
+			dst, err := os.Create(savePath)
+			if err != nil {
+				http.Error(w, "Cannot save video", http.StatusInternalServerError)
+				return
+			}
+			defer dst.Close()
+
+			if _, err := io.Copy(dst, file); err != nil {
+				http.Error(w, "Failed to write video", http.StatusInternalServerError)
+				return
+			}
+
+			uploaded = append(uploaded, models.Video{
+				Name: fileHeader.Filename,
+				Path: publicURL,
+				Type: fileHeader.Header.Get("Content-Type"),
+			})
+		}
+		videos = append(videos, uploaded...)
+	}
+
+	service.Videos = videos
 
 	now := time.Now()
 	service.UpdatedAt = &now

--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -20,6 +20,7 @@ type Ad struct {
 		AvatarPath   *string `json:"avatar_path,omitempty"`
 	} `json:"user"`
 	Images          []ImageAd  `json:"images"`
+	Videos          []Video    `json:"videos"`
 	CategoryID      int        `json:"category_id, omitempty"`
 	SubcategoryID   int        `json:"subcategory_id, omitempty"`
 	Description     string     `json:"description"`


### PR DESCRIPTION
## Summary
- add video support to ad creation and update handlers, including serving uploaded files
- persist ad videos by extending the repository queries and data model
- add database migration to introduce the ad.videos column

## Testing
- go test ./internal/...


------
https://chatgpt.com/codex/tasks/task_e_68ce9a7cb9708324bde831166570e816