### PR TITLE
Fix subscription slot usage tracking

### DIFF
--- a/internal/handlers/ad_handler.go
+++ b/internal/handlers/ad_handler.go
@@ -377,7 +377,7 @@ func (h *AdHandler) CreateAd(w http.ResponseWriter, r *http.Request) {
 	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
 	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
 	service.Top = r.FormValue("top")
-	service.Status = r.FormValue("status")
+	service.Status = normalizeListingStatus(r.FormValue("status"))
 	service.CreatedAt = time.Now()
 
 	// Сохраняем изображения
@@ -551,7 +551,7 @@ func (h *AdHandler) UpdateAd(w http.ResponseWriter, r *http.Request) {
 		service.Liked = r.FormValue("liked") == "true"
 	}
 	if _, ok := r.MultipartForm.Value["status"]; ok {
-		service.Status = r.FormValue("status")
+		service.Status = normalizeListingStatus(r.FormValue("status"))
 	}
 
 	if v, ok := r.MultipartForm.Value["latitude"]; ok {

--- a/internal/handlers/helper_status.go
+++ b/internal/handlers/helper_status.go
@@ -1,0 +1,17 @@
+package handlers
+
+import "strings"
+
+// normalizeListingStatus ensures that a listing has a persisted status value.
+// Some clients omit the status field when creating a listing which resulted in
+// empty strings being stored in the database. Empty statuses were ignored by the
+// subscription counters, so slots were never consumed. To avoid this, default
+// to "pending" which still represents a non-archived listing but can be counted
+// as an active paid slot.
+func normalizeListingStatus(status string) string {
+	status = strings.TrimSpace(status)
+	if status == "" {
+		return "pending"
+	}
+	return status
+}

--- a/internal/handlers/rent_ad_handler.go
+++ b/internal/handlers/rent_ad_handler.go
@@ -381,7 +381,7 @@ func (h *RentAdHandler) CreateRentAd(w http.ResponseWriter, r *http.Request) {
 	service.Latitude = r.FormValue("latitude")
 	service.Longitude = r.FormValue("longitude")
 	service.Top = r.FormValue("top")
-	service.Status = r.FormValue("status")
+	service.Status = normalizeListingStatus(r.FormValue("status"))
 	service.CreatedAt = time.Now()
 
 	// Сохраняем изображения
@@ -567,7 +567,7 @@ func (h *RentAdHandler) UpdateRentAd(w http.ResponseWriter, r *http.Request) {
 		service.Liked = r.FormValue("liked") == "true"
 	}
 	if _, ok := r.MultipartForm.Value["status"]; ok {
-		service.Status = r.FormValue("status")
+		service.Status = normalizeListingStatus(r.FormValue("status"))
 	}
 
 	images := service.Images

--- a/internal/handlers/rent_handler.go
+++ b/internal/handlers/rent_handler.go
@@ -400,7 +400,7 @@ func (h *RentHandler) CreateRent(w http.ResponseWriter, r *http.Request) {
 	service.Latitude = r.FormValue("latitude")
 	service.Longitude = r.FormValue("longitude")
 	service.Top = r.FormValue("top")
-	service.Status = r.FormValue("status")
+	service.Status = normalizeListingStatus(r.FormValue("status"))
 	service.CreatedAt = time.Now()
 
 	// Сохраняем изображения
@@ -592,7 +592,7 @@ func (h *RentHandler) UpdateRent(w http.ResponseWriter, r *http.Request) {
 		service.Liked = r.FormValue("liked") == "true"
 	}
 	if _, ok := r.MultipartForm.Value["status"]; ok {
-		service.Status = r.FormValue("status")
+		service.Status = normalizeListingStatus(r.FormValue("status"))
 	}
 
 	images := service.Images

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -397,7 +397,7 @@ func (h *ServiceHandler) CreateService(w http.ResponseWriter, r *http.Request) {
 	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
 	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
 	service.Top = r.FormValue("top")
-	service.Status = r.FormValue("status")
+	service.Status = normalizeListingStatus(r.FormValue("status"))
 	if v := r.FormValue("latitude"); v != "" {
 		service.Latitude = &v
 	}
@@ -597,7 +597,7 @@ func (h *ServiceHandler) UpdateService(w http.ResponseWriter, r *http.Request) {
 		service.Liked = r.FormValue("liked") == "true"
 	}
 	if _, ok := r.MultipartForm.Value["status"]; ok {
-		service.Status = r.FormValue("status")
+		service.Status = normalizeListingStatus(r.FormValue("status"))
 	}
 	if v, ok := r.MultipartForm.Value["latitude"]; ok {
 		lat := v[0]

--- a/internal/handlers/work_ad_handler.go
+++ b/internal/handlers/work_ad_handler.go
@@ -393,7 +393,7 @@ func (h *WorkAdHandler) CreateWorkAd(w http.ResponseWriter, r *http.Request) {
 	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
 	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
 	service.Top = r.FormValue("top")
-	service.Status = r.FormValue("status")
+	service.Status = normalizeListingStatus(r.FormValue("status"))
 	service.WorkExperience = r.FormValue("work_experience")
 	service.CityID, _ = strconv.Atoi(r.FormValue("city_id"))
 	service.Schedule = r.FormValue("schedule")
@@ -574,7 +574,7 @@ func (h *WorkAdHandler) UpdateWorkAd(w http.ResponseWriter, r *http.Request) {
 		service.Liked = r.FormValue("liked") == "true"
 	}
 	if _, ok := r.MultipartForm.Value["status"]; ok {
-		service.Status = r.FormValue("status")
+		service.Status = normalizeListingStatus(r.FormValue("status"))
 	}
 	if _, ok := r.MultipartForm.Value["work_experience"]; ok {
 		service.WorkExperience = r.FormValue("work_experience")

--- a/internal/handlers/work_handler.go
+++ b/internal/handlers/work_handler.go
@@ -408,7 +408,7 @@ func (h *WorkHandler) CreateWork(w http.ResponseWriter, r *http.Request) {
 	service.SubcategoryID, _ = strconv.Atoi(r.FormValue("subcategory_id"))
 	service.AvgRating, _ = strconv.ParseFloat(r.FormValue("avg_rating"), 64)
 	service.Top = r.FormValue("top")
-	service.Status = r.FormValue("status")
+	service.Status = normalizeListingStatus(r.FormValue("status"))
 	service.WorkExperience = r.FormValue("work_experience")
 	service.CityID, _ = strconv.Atoi(r.FormValue("city_id"))
 	service.Schedule = r.FormValue("schedule")
@@ -594,7 +594,7 @@ func (h *WorkHandler) UpdateWork(w http.ResponseWriter, r *http.Request) {
 		service.Liked = r.FormValue("liked") == "true"
 	}
 	if _, ok := r.MultipartForm.Value["status"]; ok {
-		service.Status = r.FormValue("status")
+		service.Status = normalizeListingStatus(r.FormValue("status"))
 	}
 	if _, ok := r.MultipartForm.Value["work_experience"]; ok {
 		service.WorkExperience = r.FormValue("work_experience")

--- a/internal/repositories/subscription_repository.go
+++ b/internal/repositories/subscription_repository.go
@@ -32,15 +32,16 @@ func (r *SubscriptionRepository) GetResponses(ctx context.Context, userID int) (
 
 func (r *SubscriptionRepository) CountActiveExecutorListings(ctx context.Context, userID int) (int, error) {
 	query := `
-        SELECT
-            (SELECT COUNT(*) FROM service WHERE user_id = ? AND status = 'active') +
-            (SELECT COUNT(*) FROM work WHERE user_id = ? AND status = 'active') +
-            (SELECT COUNT(*) FROM work_ad WHERE user_id = ? AND status = 'active') +
-            (SELECT COUNT(*) FROM rent WHERE user_id = ? AND status = 'active') +
-            (SELECT COUNT(*) FROM rent_ad WHERE user_id = ? AND status = 'active')
-    `
+    SELECT
+        (SELECT COUNT(*) FROM service WHERE user_id = ? AND status IN ('active', 'pending')) +
+        (SELECT COUNT(*) FROM ad WHERE user_id = ? AND status IN ('active', 'pending')) +
+        (SELECT COUNT(*) FROM work WHERE user_id = ? AND status IN ('active', 'pending')) +
+        (SELECT COUNT(*) FROM work_ad WHERE user_id = ? AND status IN ('active', 'pending')) +
+        (SELECT COUNT(*) FROM rent WHERE user_id = ? AND status IN ('active', 'pending')) +
+        (SELECT COUNT(*) FROM rent_ad WHERE user_id = ? AND status IN ('active', 'pending'))
+`
 	var count int
-	err := r.DB.QueryRowContext(ctx, query, userID, userID, userID, userID, userID).Scan(&count)
+	err := r.DB.QueryRowContext(ctx, query, userID, userID, userID, userID, userID, userID).Scan(&count)
 	return count, err
 }
 


### PR DESCRIPTION
## Summary
- normalize listing status handling so empty statuses default to `pending`
- update subscription slot counting to include ads and treat pending listings as consuming a slot

## Testing
- go test ./... *(hangs waiting for external dependencies, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68d0083cadf88324b9c6da3809e54dc6