### PR TITLE
Allow work and rent creation with active subscription

### DIFF
--- a/internal/services/rent_service.go
+++ b/internal/services/rent_service.go
@@ -12,7 +12,7 @@ type RentService struct {
 }
 
 func (s *RentService) CreateRent(ctx context.Context, work models.Rent) (models.Rent, error) {
-	has, err := s.SubscriptionRepo.HasActiveSubscription(ctx, work.UserID)
+	has, err := s.SubscriptionRepo.HasActiveSubscriptionPlan(ctx, work.UserID)
 	if err != nil {
 		return models.Rent{}, err
 	}
@@ -33,7 +33,7 @@ func (s *RentService) UpdateRent(ctx context.Context, work models.Rent) (models.
 			return models.Rent{}, err
 		}
 		if existing.Status != "active" {
-			has, err := s.SubscriptionRepo.HasActiveSubscription(ctx, work.UserID)
+			has, err := s.SubscriptionRepo.HasActiveSubscriptionPlan(ctx, work.UserID)
 			if err != nil {
 				return models.Rent{}, err
 			}

--- a/internal/services/work_service.go
+++ b/internal/services/work_service.go
@@ -12,7 +12,7 @@ type WorkService struct {
 }
 
 func (s *WorkService) CreateWork(ctx context.Context, work models.Work) (models.Work, error) {
-	has, err := s.SubscriptionRepo.HasActiveSubscription(ctx, work.UserID)
+	has, err := s.SubscriptionRepo.HasActiveSubscriptionPlan(ctx, work.UserID)
 	if err != nil {
 		return models.Work{}, err
 	}
@@ -33,7 +33,7 @@ func (s *WorkService) UpdateWork(ctx context.Context, work models.Work) (models.
 			return models.Work{}, err
 		}
 		if existing.Status != "active" {
-			has, err := s.SubscriptionRepo.HasActiveSubscription(ctx, work.UserID)
+			has, err := s.SubscriptionRepo.HasActiveSubscriptionPlan(ctx, work.UserID)
 			if err != nil {
 				return models.Work{}, err
 			}


### PR DESCRIPTION
## Summary
- add a helper that checks for any active subscription plan without validating slot usage
- reuse the relaxed subscription check in work and rent services so listings can be created when a user has an active plan

## Testing
- `go test ./... -run TestNonexistent -count=0` *(fails: command hung in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d01b3967788324b8ea6e8525dee59b