### PR TITLE
Add endpoint to verify email confirmation code

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -37,6 +37,7 @@ func (app *application) routes() http.Handler {
 	mux.Post("/user/change_number", standardMiddleware.ThenFunc(app.userHandler.ChangeNumber)) //РАБОТАЕТ
 	mux.Post("/user/change_email", standardMiddleware.ThenFunc(app.userHandler.ChangeEmail))   //РАБОТАЕТ
 	mux.Post("/user/send_email_code", standardMiddleware.ThenFunc(app.userHandler.SendCodeToEmail))
+	mux.Post("/user/code_check", standardMiddleware.ThenFunc(app.userHandler.CheckVerificationCode))
 	mux.Put("/user/:id/city", authMiddleware.ThenFunc(app.userHandler.ChangeCityForUser))
 	mux.Get("/docs/:filename", authMiddleware.ThenFunc(app.userHandler.ServeProofDocument))
 	mux.Post("/user/:id/avatar", authMiddleware.ThenFunc(app.userHandler.UploadAvatar))


### PR DESCRIPTION
## Summary
- register a new /user/code_check route for verifying email confirmation codes
- add handler and service logic to compare a submitted code with the stored value
- reuse the shared verification check during sign up to avoid duplication

## Testing
- go test ./... *(fails: hangs indefinitely, aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fc289ce88324bc002d25b20c17c6