### PR TITLE
Allow deleting media in service update API

### DIFF
--- a/internal/handlers/image_utils_test.go
+++ b/internal/handlers/image_utils_test.go
@@ -65,3 +65,44 @@ func TestGatherImagesFromFormInvalidValuesIgnored(t *testing.T) {
 		t.Fatalf("expected zero videos, got %d", len(videos))
 	}
 }
+
+func TestGatherStringsFromForm(t *testing.T) {
+	form := &multipart.Form{
+		Value: map[string][]string{
+			"delete_images": []string{"[\"/a.jpg\", \"\", \"null\"]", "/b.jpg"},
+		},
+	}
+
+	values, ok, err := gatherStringsFromForm(form, "delete_images")
+	if err != nil {
+		t.Fatalf("gatherStringsFromForm returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok=true when valid values present")
+	}
+	if len(values) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(values))
+	}
+	if values[0] != "/a.jpg" || values[1] != "/b.jpg" {
+		t.Fatalf("unexpected values: %#v", values)
+	}
+}
+
+func TestGatherStringsFromFormEmpty(t *testing.T) {
+	form := &multipart.Form{
+		Value: map[string][]string{
+			"delete_images": []string{"", "null", "undefined"},
+		},
+	}
+
+	values, ok, err := gatherStringsFromForm(form, "delete_images")
+	if err != nil {
+		t.Fatalf("gatherStringsFromForm returned error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when no valid values present")
+	}
+	if len(values) != 0 {
+		t.Fatalf("expected zero values, got %d", len(values))
+	}
+}

--- a/internal/handlers/service_handler.go
+++ b/internal/handlers/service_handler.go
@@ -570,6 +570,18 @@ func (h *ServiceHandler) UpdateService(w http.ResponseWriter, r *http.Request) {
 
 	service := existingService
 
+	deletedImageKeys, _, err := gatherStringsFromForm(r.MultipartForm, "delete_images", "delete_images[]", "removed_images", "removed_images[]")
+	if err != nil {
+		http.Error(w, "Invalid delete images payload", http.StatusBadRequest)
+		return
+	}
+
+	deletedVideoKeys, _, err := gatherStringsFromForm(r.MultipartForm, "delete_videos", "delete_videos[]", "removed_videos", "removed_videos[]")
+	if err != nil {
+		http.Error(w, "Invalid delete videos payload", http.StatusBadRequest)
+		return
+	}
+
 	if _, ok := r.MultipartForm.Value["name"]; ok {
 		service.Name = r.FormValue("name")
 	}
@@ -678,6 +690,14 @@ func (h *ServiceHandler) UpdateService(w http.ResponseWriter, r *http.Request) {
 		images = append(images, uploaded...)
 	}
 
+	if len(deletedImageKeys) > 0 {
+		var removedImages []models.Image
+		images, removedImages = filterServiceImages(images, deletedImageKeys)
+		if err := removeServiceImagesFromDisk(removedImages); err != nil {
+			log.Printf("Failed to remove service images: %v", err)
+		}
+	}
+
 	service.Images = images
 
 	videos := service.Videos
@@ -743,6 +763,14 @@ func (h *ServiceHandler) UpdateService(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		videos = append(videos, uploaded...)
+	}
+
+	if len(deletedVideoKeys) > 0 {
+		var removedVideos []models.Video
+		videos, removedVideos = filterServiceVideos(videos, deletedVideoKeys)
+		if err := removeServiceVideosFromDisk(removedVideos); err != nil {
+			log.Printf("Failed to remove service videos: %v", err)
+		}
 	}
 
 	service.Videos = videos
@@ -848,4 +876,128 @@ func (h *ServiceHandler) GetServiceByServiceIDAndUserID(w http.ResponseWriter, r
 		log.Printf("[ERROR] Failed to encode response: %v", err)
 		http.Error(w, "failed to encode response", http.StatusInternalServerError)
 	}
+}
+
+func filterServiceImages(images []models.Image, deleteKeys []string) ([]models.Image, []models.Image) {
+	removalSet := buildRemovalSet(deleteKeys)
+	if len(removalSet) == 0 {
+		return images, nil
+	}
+
+	var (
+		kept    []models.Image
+		removed []models.Image
+	)
+
+	for _, img := range images {
+		if shouldRemoveMedia(img.Path, img.Name, removalSet) {
+			removed = append(removed, img)
+			continue
+		}
+		kept = append(kept, img)
+	}
+
+	return kept, removed
+}
+
+func filterServiceVideos(videos []models.Video, deleteKeys []string) ([]models.Video, []models.Video) {
+	removalSet := buildRemovalSet(deleteKeys)
+	if len(removalSet) == 0 {
+		return videos, nil
+	}
+
+	var (
+		kept    []models.Video
+		removed []models.Video
+	)
+
+	for _, video := range videos {
+		if shouldRemoveMedia(video.Path, video.Name, removalSet) {
+			removed = append(removed, video)
+			continue
+		}
+		kept = append(kept, video)
+	}
+
+	return kept, removed
+}
+
+func removeServiceImagesFromDisk(images []models.Image) error {
+	for _, img := range images {
+		if img.Type == "link" {
+			continue
+		}
+		if err := removeMediaFile("cmd/uploads/services", "/images/services/", img.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeServiceVideosFromDisk(videos []models.Video) error {
+	for _, video := range videos {
+		if video.Type == "link" {
+			continue
+		}
+		if err := removeMediaFile("cmd/uploads/services/videos", "/videos/services/", video.Path); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func buildRemovalSet(keys []string) map[string]struct{} {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	set := make(map[string]struct{}, len(keys))
+	for _, key := range keys {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		set[key] = struct{}{}
+	}
+	return set
+}
+
+func shouldRemoveMedia(path, name string, removalSet map[string]struct{}) bool {
+	if removalSet == nil {
+		return false
+	}
+	if _, ok := removalSet[path]; ok {
+		return true
+	}
+	if name != "" {
+		if _, ok := removalSet[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func removeMediaFile(baseDir, publicPrefix, publicPath string) error {
+	if !strings.HasPrefix(publicPath, publicPrefix) {
+		return nil
+	}
+
+	relative := strings.TrimPrefix(publicPath, publicPrefix)
+	if relative == "" {
+		return nil
+	}
+
+	cleanRelative := filepath.Clean(relative)
+	if cleanRelative == "." || strings.HasPrefix(cleanRelative, "..") || filepath.IsAbs(cleanRelative) {
+		return fmt.Errorf("invalid media path: %s", publicPath)
+	}
+
+	fsPath := filepath.Join(baseDir, cleanRelative)
+	if err := os.Remove(fsPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary
- allow the service update handler to accept lists of images or videos to delete
- filter deleted media from the payload and remove corresponding local files
- add a multipart helper for parsing string lists and unit tests covering it

## Testing
- go test ./internal/handlers -run TestGatherStringsFromForm -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d1ac5862488324a5d7f5cad876fcf0