### PR TITLE
Allow deleting service media via file uploads

### DIFF
--- a/internal/handlers/image_utils.go
+++ b/internal/handlers/image_utils.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"io"
 	"mime/multipart"
 	"strconv"
 	"strings"
@@ -56,6 +57,192 @@ func gatherImagesFromForm[T imagePayload](form *multipart.Form, keys ...string) 
 	}
 
 	return images, true, nil
+}
+
+// gatherStringsFromForm reads textual payloads from multipart values and normalizes them into a slice of strings.
+// The helper understands JSON arrays of strings as well as repeated individual values.
+func gatherStringsFromForm(form *multipart.Form, keys ...string) ([]string, bool, error) {
+	if form == nil {
+		return nil, false, nil
+	}
+
+	var rawValues []string
+	for _, key := range keys {
+		if values, ok := form.Value[key]; ok {
+			rawValues = append(rawValues, values...)
+		}
+	}
+	if len(rawValues) == 0 {
+		return nil, false, nil
+	}
+
+	result := parseStringList(rawValues)
+	if len(result) == 0 {
+		return nil, false, nil
+	}
+
+	return result, true, nil
+}
+
+// gatherStringsFromFormFiles extracts textual identifiers from multipart file parts.
+// It records filenames as potential keys and, when the payload is textual, attempts
+// to parse file contents as lists of strings (JSON arrays or plain values).
+func gatherStringsFromFormFiles(form *multipart.Form, keys ...string) ([]string, bool, error) {
+	if form == nil {
+		return nil, false, nil
+	}
+
+	var rawValues []string
+	for _, key := range keys {
+		fileHeaders := form.File[key]
+		for _, header := range fileHeaders {
+			if header == nil {
+				continue
+			}
+
+			if filename := strings.TrimSpace(header.Filename); filename != "" {
+				rawValues = append(rawValues, filename)
+			}
+
+			if !shouldReadTextPayload(header) {
+				continue
+			}
+
+			file, err := header.Open()
+			if err != nil {
+				return nil, false, err
+			}
+
+			data, err := io.ReadAll(io.LimitReader(file, maxTextualPayloadSize))
+			file.Close()
+			if err != nil {
+				return nil, false, err
+			}
+			if len(data) == 0 {
+				continue
+			}
+
+			rawValues = append(rawValues, string(data))
+		}
+	}
+
+	if len(rawValues) == 0 {
+		return nil, false, nil
+	}
+
+	result := parseStringList(rawValues)
+	if len(result) == 0 {
+		return nil, false, nil
+	}
+
+	return result, true, nil
+}
+
+const maxTextualPayloadSize = 1 << 20 // 1 MiB
+
+func shouldReadTextPayload(header *multipart.FileHeader) bool {
+	if header == nil {
+		return false
+	}
+
+	if isTextualContentType(header.Header.Get("Content-Type")) {
+		return true
+	}
+
+	filename := strings.ToLower(strings.TrimSpace(header.Filename))
+	if filename == "" {
+		return false
+	}
+
+	switch {
+	case strings.HasSuffix(filename, ".json"), strings.HasSuffix(filename, ".txt"), strings.HasSuffix(filename, ".csv"):
+		return true
+	}
+
+	return false
+}
+
+func isTextualContentType(contentType string) bool {
+	if contentType == "" {
+		return true
+	}
+
+	ct := strings.ToLower(contentType)
+	if strings.HasPrefix(ct, "text/") {
+		return true
+	}
+
+	switch ct {
+	case "application/json", "application/javascript", "application/xml", "application/yaml", "application/x-yaml":
+		return true
+	}
+
+	return false
+}
+
+func parseStringList(rawValues []string) []string {
+	var result []string
+
+	for _, raw := range rawValues {
+		entries := normalizeRawString(raw)
+		result = append(result, entries...)
+	}
+
+	return result
+}
+
+func normalizeRawString(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" || raw == "undefined" {
+		return nil
+	}
+
+	if strings.HasPrefix(raw, "[") {
+		var arr []string
+		if err := json.Unmarshal([]byte(raw), &arr); err == nil {
+			var parsed []string
+			for _, item := range arr {
+				item = strings.TrimSpace(item)
+				if item == "" || item == "null" || item == "undefined" {
+					continue
+				}
+				parsed = append(parsed, item)
+			}
+			if len(parsed) > 0 {
+				return parsed
+			}
+		}
+	}
+
+	if strings.ContainsAny(raw, "\n\r") {
+		lines := strings.FieldsFunc(raw, func(r rune) bool {
+			return r == '\n' || r == '\r'
+		})
+		var parsed []string
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" || line == "null" || line == "undefined" {
+				continue
+			}
+			parsed = append(parsed, line)
+		}
+		if len(parsed) > 0 {
+			return parsed
+		}
+	}
+
+	if strings.HasPrefix(raw, "\"") && strings.HasSuffix(raw, "\"") {
+		if unquoted, err := strconv.Unquote(raw); err == nil {
+			raw = unquoted
+		}
+	}
+
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" || raw == "undefined" {
+		return nil
+	}
+
+	return []string{raw}
 }
 
 func parseImagesFromValues[T imagePayload](values []string) ([]T, error) {

--- a/internal/handlers/image_utils_test.go
+++ b/internal/handlers/image_utils_test.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"bytes"
 	"mime/multipart"
+	"net/http/httptest"
 	"testing"
 
 	"naimuBack/internal/models"
@@ -63,5 +65,122 @@ func TestGatherImagesFromFormInvalidValuesIgnored(t *testing.T) {
 
 	if len(videos) != 0 {
 		t.Fatalf("expected zero videos, got %d", len(videos))
+	}
+}
+
+func TestGatherStringsFromForm(t *testing.T) {
+	form := &multipart.Form{
+		Value: map[string][]string{
+			"delete_images": []string{"[\"/a.jpg\", \"\", \"null\"]", "/b.jpg"},
+		},
+	}
+
+	values, ok, err := gatherStringsFromForm(form, "delete_images")
+	if err != nil {
+		t.Fatalf("gatherStringsFromForm returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok=true when valid values present")
+	}
+	if len(values) != 2 {
+		t.Fatalf("expected 2 values, got %d", len(values))
+	}
+	if values[0] != "/a.jpg" || values[1] != "/b.jpg" {
+		t.Fatalf("unexpected values: %#v", values)
+	}
+}
+
+func TestGatherStringsFromFormEmpty(t *testing.T) {
+	form := &multipart.Form{
+		Value: map[string][]string{
+			"delete_images": []string{"", "null", "undefined"},
+		},
+	}
+
+	values, ok, err := gatherStringsFromForm(form, "delete_images")
+	if err != nil {
+		t.Fatalf("gatherStringsFromForm returned error: %v", err)
+	}
+	if ok {
+		t.Fatalf("expected ok=false when no valid values present")
+	}
+	if len(values) != 0 {
+		t.Fatalf("expected zero values, got %d", len(values))
+	}
+}
+
+func TestGatherStringsFromFormFilesUsesFilename(t *testing.T) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	part, err := writer.CreateFormFile("delete_images[]", "old_photo.jpg")
+	if err != nil {
+		t.Fatalf("CreateFormFile failed: %v", err)
+	}
+	if _, err := part.Write([]byte("")); err != nil {
+		t.Fatalf("writing to form file failed: %v", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("closing writer failed: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if err := req.ParseMultipartForm(1024); err != nil {
+		t.Fatalf("ParseMultipartForm failed: %v", err)
+	}
+
+	values, ok, err := gatherStringsFromFormFiles(req.MultipartForm, "delete_images", "delete_images[]")
+	if err != nil {
+		t.Fatalf("gatherStringsFromFormFiles returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok=true when file payload provided")
+	}
+	if len(values) != 1 {
+		t.Fatalf("expected a single filename entry, got %d", len(values))
+	}
+	if values[0] != "old_photo.jpg" {
+		t.Fatalf("unexpected filename parsed: %v", values)
+	}
+}
+
+func TestGatherStringsFromFormFilesParsesJSONPayload(t *testing.T) {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	part, err := writer.CreateFormFile("delete_images", "payload.json")
+	if err != nil {
+		t.Fatalf("CreateFormFile failed: %v", err)
+	}
+	if _, err := part.Write([]byte(`["/a.jpg","/b.jpg"]`)); err != nil {
+		t.Fatalf("writing to form file failed: %v", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("closing writer failed: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if err := req.ParseMultipartForm(1024); err != nil {
+		t.Fatalf("ParseMultipartForm failed: %v", err)
+	}
+
+	values, ok, err := gatherStringsFromFormFiles(req.MultipartForm, "delete_images")
+	if err != nil {
+		t.Fatalf("gatherStringsFromFormFiles returned error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected ok=true when textual file payload provided")
+	}
+
+	if len(values) != 3 {
+		t.Fatalf("expected filename plus two entries, got %d (%v)", len(values), values)
+	}
+
+	if values[1] != "/a.jpg" || values[2] != "/b.jpg" {
+		t.Fatalf("unexpected parsed values: %v", values)
 	}
 }


### PR DESCRIPTION
## Summary
- extend multipart helpers to normalize deletion keys from file parts as well as text values
- update the service update handler to merge deletion requests coming from file uploads
- add tests covering filename-based and JSON file deletion payloads

## Testing
- go test ./internal/handlers

------
https://chatgpt.com/codex/tasks/task_e_68d1ac5862488324a5d7f5cad876fcf0