### PR TITLE
Adjust filtered work and rent response field names

### DIFF
--- a/internal/models/rent.go
+++ b/internal/models/rent.go
@@ -74,21 +74,21 @@ type FilterRentRequest struct {
 }
 
 type FilteredRent struct {
-	UserID             int         `json:"user_id"`
-	UserName           string      `json:"user_name"`
-	UserSurname        string      `json:"user_surname"`
-	UserPhone          string      `json:"-"`
-	UserAvatarPath     *string     `json:"user_avatar_path,omitempty"`
-	UserRating         float64     `json:"user_rating"`
-	UserReviewsCount   int         `json:"user_reviews_count"`
-	ServiceID          int         `json:"service_id"`
-	ServiceName        string      `json:"service_name"`
-	ServicePrice       float64     `json:"service_price"`
-	ServiceDescription string      `json:"service_description"`
-	Images             []ImageRent `json:"images"`
-	Videos             []Video     `json:"videos"`
-	ServiceLatitude    string      `json:"latitude"`
-	ServiceLongitude   string      `json:"longitude"`
-	Liked              bool        `json:"liked"`
-	Responded          bool        `json:"is_responded"`
+	UserID           int         `json:"user_id"`
+	UserName         string      `json:"user_name"`
+	UserSurname      string      `json:"user_surname"`
+	UserPhone        string      `json:"-"`
+	UserAvatarPath   *string     `json:"user_avatar_path,omitempty"`
+	UserRating       float64     `json:"user_rating"`
+	UserReviewsCount int         `json:"user_reviews_count"`
+	RentID           int         `json:"rent_id"`
+	RentName         string      `json:"rent_name"`
+	RentPrice        float64     `json:"rent_price"`
+	RentDescription  string      `json:"rent_description"`
+	Images           []ImageRent `json:"images"`
+	Videos           []Video     `json:"videos"`
+	RentLatitude     string      `json:"latitude"`
+	RentLongitude    string      `json:"longitude"`
+	Liked            bool        `json:"liked"`
+	Responded        bool        `json:"is_responded"`
 }

--- a/internal/models/work.go
+++ b/internal/models/work.go
@@ -79,21 +79,21 @@ type FilterWorkRequest struct {
 }
 
 type FilteredWork struct {
-	UserID             int         `json:"user_id"`
-	UserName           string      `json:"user_name"`
-	UserSurname        string      `json:"user_surname"`
-	UserPhone          string      `json:"-"`
-	UserAvatarPath     *string     `json:"user_avatar_path,omitempty"`
-	UserRating         float64     `json:"user_rating"`
-	UserReviewsCount   int         `json:"user_reviews_count"`
-	ServiceID          int         `json:"service_id"`
-	ServiceName        string      `json:"service_name"`
-	ServicePrice       float64     `json:"service_price"`
-	ServiceDescription string      `json:"service_description"`
-	Images             []ImageWork `json:"images"`
-	Videos             []Video     `json:"videos"`
-	ServiceLatitude    string      `json:"latitude"`
-	ServiceLongitude   string      `json:"longitude"`
-	Liked              bool        `json:"liked"`
-	Responded          bool        `json:"is_responded"`
+	UserID           int         `json:"user_id"`
+	UserName         string      `json:"user_name"`
+	UserSurname      string      `json:"user_surname"`
+	UserPhone        string      `json:"-"`
+	UserAvatarPath   *string     `json:"user_avatar_path,omitempty"`
+	UserRating       float64     `json:"user_rating"`
+	UserReviewsCount int         `json:"user_reviews_count"`
+	WorkID           int         `json:"work_id"`
+	WorkName         string      `json:"work_name"`
+	WorkPrice        float64     `json:"work_price"`
+	WorkDescription  string      `json:"work_description"`
+	Images           []ImageWork `json:"images"`
+	Videos           []Video     `json:"videos"`
+	WorkLatitude     string      `json:"latitude"`
+	WorkLongitude    string      `json:"longitude"`
+	Liked            bool        `json:"liked"`
+	Responded        bool        `json:"is_responded"`
 }

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -474,15 +474,15 @@ WHERE 1=1
 		var imagesJSON, videosJSON []byte
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon, &imagesJSON, &videosJSON,
+			&s.RentID, &s.RentName, &s.RentPrice, &s.RentDescription, &lat, &lon, &imagesJSON, &videosJSON,
 		); err != nil {
 			return nil, err
 		}
 		if lat.Valid {
-			s.ServiceLatitude = lat.String
+			s.RentLatitude = lat.String
 		}
 		if lon.Valid {
-			s.ServiceLongitude = lon.String
+			s.RentLongitude = lon.String
 		}
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, fmt.Errorf("failed to decode images json: %w", err)
@@ -655,16 +655,16 @@ WHERE 1=1
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon, &imagesJSON, &videosJSON, &likedStr, &respondedStr,
+			&s.RentID, &s.RentName, &s.RentPrice, &s.RentDescription, &lat, &lon, &imagesJSON, &videosJSON, &likedStr, &respondedStr,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 		if lat.Valid {
-			s.ServiceLatitude = lat.String
+			s.RentLatitude = lat.String
 		}
 		if lon.Valid {
-			s.ServiceLongitude = lon.String
+			s.RentLongitude = lon.String
 		}
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, fmt.Errorf("failed to decode images json: %w", err)

--- a/internal/repositories/work_repository.go
+++ b/internal/repositories/work_repository.go
@@ -467,15 +467,15 @@ WHERE 1=1
 		var imagesJSON, videosJSON []byte
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon, &imagesJSON, &videosJSON,
+			&s.WorkID, &s.WorkName, &s.WorkPrice, &s.WorkDescription, &lat, &lon, &imagesJSON, &videosJSON,
 		); err != nil {
 			return nil, err
 		}
 		if lat.Valid {
-			s.ServiceLatitude = lat.String
+			s.WorkLatitude = lat.String
 		}
 		if lon.Valid {
-			s.ServiceLongitude = lon.String
+			s.WorkLongitude = lon.String
 		}
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, fmt.Errorf("failed to decode images json: %w", err)
@@ -641,16 +641,16 @@ WHERE 1=1
 		if err := rows.Scan(
 			&s.UserID, &s.UserName, &s.UserSurname, &s.UserAvatarPath, &s.UserRating,
 
-			&s.ServiceID, &s.ServiceName, &s.ServicePrice, &s.ServiceDescription, &lat, &lon, &imagesJSON, &videosJSON, &likedStr, &respondedStr,
+			&s.WorkID, &s.WorkName, &s.WorkPrice, &s.WorkDescription, &lat, &lon, &imagesJSON, &videosJSON, &likedStr, &respondedStr,
 		); err != nil {
 			log.Printf("[ERROR] Failed to scan row: %v", err)
 			return nil, fmt.Errorf("failed to scan row: %w", err)
 		}
 		if lat.Valid {
-			s.ServiceLatitude = lat.String
+			s.WorkLatitude = lat.String
 		}
 		if lon.Valid {
-			s.ServiceLongitude = lon.String
+			s.WorkLongitude = lon.String
 		}
 		if err := json.Unmarshal(imagesJSON, &s.Images); err != nil {
 			return nil, fmt.Errorf("failed to decode images json: %w", err)


### PR DESCRIPTION
## Summary
- rename filtered work response fields and JSON tags to use work-specific names
- rename filtered rent response fields and JSON tags to use rent-specific names
- update repository scans to populate the new work and rent field names

## Testing
- `go test ./...` *(hangs, had to cancel in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d25b7fe6dc83248e6a795c20828601