### PR TITLE
Include media data in filtered ads responses

### DIFF
--- a/internal/models/ad.go
+++ b/internal/models/ad.go
@@ -72,19 +72,21 @@ type FilterAdRequest struct {
 }
 
 type FilteredAd struct {
-	UserID           int     `json:"user_id"`
-	UserName         string  `json:"user_name"`
-	UserSurname      string  `json:"user_surname"`
-	UserPhone        string  `json:"-"`
-	UserAvatarPath   *string `json:"user_avatar_path,omitempty"`
-	UserRating       float64 `json:"user_rating"`
-	UserReviewsCount int     `json:"user_reviews_count"`
-	AdID             int     `json:"ad_id"`
-	AdName           string  `json:"ad_name"`
-	AdPrice          float64 `json:"ad_price"`
-	AdDescription    string  `json:"ad_description"`
-	AdLatitude       *string `json:"latitude"`
-	AdLongitude      *string `json:"longitude"`
-	Liked            bool    `json:"liked"`
-	Responded        bool    `json:"is_responded"`
+	UserID           int       `json:"user_id"`
+	UserName         string    `json:"user_name"`
+	UserSurname      string    `json:"user_surname"`
+	UserPhone        string    `json:"-"`
+	UserAvatarPath   *string   `json:"user_avatar_path,omitempty"`
+	UserRating       float64   `json:"user_rating"`
+	UserReviewsCount int       `json:"user_reviews_count"`
+	AdID             int       `json:"ad_id"`
+	AdName           string    `json:"ad_name"`
+	AdPrice          float64   `json:"ad_price"`
+	AdDescription    string    `json:"ad_description"`
+	Images           []ImageAd `json:"images"`
+	Videos           []Video   `json:"videos"`
+	AdLatitude       *string   `json:"latitude"`
+	AdLongitude      *string   `json:"longitude"`
+	Liked            bool      `json:"liked"`
+	Responded        bool      `json:"is_responded"`
 }

--- a/internal/models/rent_ad.go
+++ b/internal/models/rent_ad.go
@@ -74,19 +74,21 @@ type FilterRentAdRequest struct {
 }
 
 type FilteredRentAd struct {
-	UserID            int     `json:"user_id"`
-	UserName          string  `json:"user_name"`
-	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"-"`
-	UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
-	UserRating        float64 `json:"user_rating"`
-	UserReviewsCount  int     `json:"user_reviews_count"`
-	RentAdID          int     `json:"rentad_id"`
-	RentAdName        string  `json:"rentad_name"`
-	RentAdPrice       float64 `json:"rentad_price"`
-	RentAdDescription string  `json:"rentad_description"`
-	RentAdLatitude    string  `json:"latitude"`
-	RentAdLongitude   string  `json:"longitude"`
-	Liked             bool    `json:"liked"`
-	Responded         bool    `json:"is_responded"`
+	UserID            int           `json:"user_id"`
+	UserName          string        `json:"user_name"`
+	UserSurname       string        `json:"user_surname"`
+	UserPhone         string        `json:"-"`
+	UserAvatarPath    *string       `json:"user_avatar_path,omitempty"`
+	UserRating        float64       `json:"user_rating"`
+	UserReviewsCount  int           `json:"user_reviews_count"`
+	RentAdID          int           `json:"rentad_id"`
+	RentAdName        string        `json:"rentad_name"`
+	RentAdPrice       float64       `json:"rentad_price"`
+	RentAdDescription string        `json:"rentad_description"`
+	Images            []ImageRentAd `json:"images"`
+	Videos            []Video       `json:"videos"`
+	RentAdLatitude    string        `json:"latitude"`
+	RentAdLongitude   string        `json:"longitude"`
+	Liked             bool          `json:"liked"`
+	Responded         bool          `json:"is_responded"`
 }

--- a/internal/models/work_ad.go
+++ b/internal/models/work_ad.go
@@ -80,19 +80,21 @@ type FilterWorkAdRequest struct {
 }
 
 type FilteredWorkAd struct {
-	UserID            int     `json:"user_id"`
-	UserName          string  `json:"user_name"`
-	UserSurname       string  `json:"user_surname"`
-	UserPhone         string  `json:"-"`
-	UserAvatarPath    *string `json:"user_avatar_path,omitempty"`
-	UserRating        float64 `json:"user_rating"`
-	UserReviewsCount  int     `json:"user_reviews_count"`
-	WorkAdID          int     `json:"workad_id"`
-	WorkAdName        string  `json:"workad_name"`
-	WorkAdPrice       float64 `json:"workad_price"`
-	WorkAdDescription string  `json:"workad_description"`
-	WorkAdLatitude    string  `json:"latitude"`
-	WorkAdLongitude   string  `json:"longitude"`
-	Liked             bool    `json:"liked"`
-	Responded         bool    `json:"is_responded"`
+	UserID            int           `json:"user_id"`
+	UserName          string        `json:"user_name"`
+	UserSurname       string        `json:"user_surname"`
+	UserPhone         string        `json:"-"`
+	UserAvatarPath    *string       `json:"user_avatar_path,omitempty"`
+	UserRating        float64       `json:"user_rating"`
+	UserReviewsCount  int           `json:"user_reviews_count"`
+	WorkAdID          int           `json:"workad_id"`
+	WorkAdName        string        `json:"workad_name"`
+	WorkAdPrice       float64       `json:"workad_price"`
+	WorkAdDescription string        `json:"workad_description"`
+	Images            []ImageWorkAd `json:"images"`
+	Videos            []Video       `json:"videos"`
+	WorkAdLatitude    string        `json:"latitude"`
+	WorkAdLongitude   string        `json:"longitude"`
+	Liked             bool          `json:"liked"`
+	Responded         bool          `json:"is_responded"`
 }


### PR DESCRIPTION
## Summary
- add media fields to filtered ad, rent ad, and work ad response models
- update filtered repository queries to select media JSON and decode it for API responses
- ensure the variants that include like/response flags also populate image and video data

## Testing
- go test ./... *(fails: hangs waiting for external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d25da75a5c8324af80454b82eaa8ba