### PR TITLE
Remove subscription requirement when creating ads

### DIFF
--- a/internal/services/ad_service.go
+++ b/internal/services/ad_service.go
@@ -12,13 +12,6 @@ type AdService struct {
 }
 
 func (s *AdService) CreateAd(ctx context.Context, ad models.Ad) (models.Ad, error) {
-	has, err := s.SubscriptionRepo.HasActiveSubscription(ctx, ad.UserID)
-	if err != nil {
-		return models.Ad{}, err
-	}
-	if !has {
-		return models.Ad{}, ErrNoActiveSubscription
-	}
 	return s.AdRepo.CreateAd(ctx, ad)
 }
 

--- a/internal/services/rent_ad_service.go
+++ b/internal/services/rent_ad_service.go
@@ -12,13 +12,6 @@ type RentAdService struct {
 }
 
 func (s *RentAdService) CreateRentAd(ctx context.Context, work models.RentAd) (models.RentAd, error) {
-	has, err := s.SubscriptionRepo.HasActiveSubscription(ctx, work.UserID)
-	if err != nil {
-		return models.RentAd{}, err
-	}
-	if !has {
-		return models.RentAd{}, ErrNoActiveSubscription
-	}
 	return s.RentAdRepo.CreateRentAd(ctx, work)
 }
 

--- a/internal/services/work_ad_service.go
+++ b/internal/services/work_ad_service.go
@@ -12,13 +12,6 @@ type WorkAdService struct {
 }
 
 func (s *WorkAdService) CreateWorkAd(ctx context.Context, work models.WorkAd) (models.WorkAd, error) {
-	has, err := s.SubscriptionRepo.HasActiveSubscription(ctx, work.UserID)
-	if err != nil {
-		return models.WorkAd{}, err
-	}
-	if !has {
-		return models.WorkAd{}, ErrNoActiveSubscription
-	}
 	return s.WorkAdRepo.CreateWorkAd(ctx, work)
 }
 


### PR DESCRIPTION
## Summary
- allow creating regular ads without requiring an active subscription
- remove subscription checks from rent ad and work ad creation flows

## Testing
- go test ./... *(fails: command hung while running; aborted with Ctrl+C)*

------
https://chatgpt.com/codex/tasks/task_e_68d507a7f58883249b671ea4f2230e06