### PR TITLE
Group executor location results by user

### DIFF
--- a/internal/models/location.go
+++ b/internal/models/location.go
@@ -16,20 +16,28 @@ type ExecutorLocationFilter struct {
 	AvgRating      []float64 `json:"avg_rating"`
 }
 
-// ExecutorLocation represents executor with current item and coordinates.
-type ExecutorLocation struct {
+// ExecutorLocationItem describes a single active item bound to an executor.
+type ExecutorLocationItem struct {
+	ID          int     `json:"id"`
+	Name        string  `json:"name"`
+	Description string  `json:"description"`
+	Price       float64 `json:"price"`
+	AvgRating   float64 `json:"avg_rating"`
+}
 
-	UserID      int      `json:"user_id"`
-	Name        string   `json:"name"`
-	Surname     string   `json:"surname"`
-	Avatar      *string  `json:"avatar,omitempty"`
-	Latitude    *float64 `json:"latitude"`
-	Longitude   *float64 `json:"longitude"`
-	ItemID      int      `json:"item_id"`
-	ItemName    string   `json:"item_name"`
-	Description string   `json:"description"`
-	Price       float64  `json:"price"`
-	AvgRating   float64  `json:"avg_rating"`
-	Type        string   `json:"type"`
+// ExecutorLocationGroup aggregates an executor's profile with all active items.
+type ExecutorLocationGroup struct {
+	UserID    int      `json:"user_id"`
+	Name      string   `json:"name"`
+	Surname   string   `json:"surname"`
+	Avatar    *string  `json:"avatar,omitempty"`
+	Latitude  *float64 `json:"latitude"`
+	Longitude *float64 `json:"longitude"`
 
+	Services []ExecutorLocationItem `json:"services"`
+	Ads      []ExecutorLocationItem `json:"ads"`
+	WorkAds  []ExecutorLocationItem `json:"work_ads"`
+	Works    []ExecutorLocationItem `json:"works"`
+	RentAds  []ExecutorLocationItem `json:"rent_ads"`
+	Rents    []ExecutorLocationItem `json:"rents"`
 }

--- a/internal/services/location_service.go
+++ b/internal/services/location_service.go
@@ -21,14 +21,12 @@ func (s *LocationService) GetLocation(ctx context.Context, userID int) (models.L
 	return s.Repo.GetLocation(ctx, userID)
 }
 
-
 // GoOffline clears coordinates and marks user offline.
 func (s *LocationService) GoOffline(ctx context.Context, userID int) error {
 	return s.Repo.ClearLocation(ctx, userID)
 }
 
-
 // GetExecutors returns online executors with active items by filter.
-func (s *LocationService) GetExecutors(ctx context.Context, f models.ExecutorLocationFilter) ([]models.ExecutorLocation, error) {
+func (s *LocationService) GetExecutors(ctx context.Context, f models.ExecutorLocationFilter) ([]models.ExecutorLocationGroup, error) {
 	return s.Repo.GetExecutors(ctx, f)
 }


### PR DESCRIPTION
## Summary
- group executor location results by user profile and attach nested arrays for each item type
- add item aggregation models and helpers for location executors

## Testing
- not run (go test ./... requires external services and hangs)


------
https://chatgpt.com/codex/tasks/task_e_68d9355d104c8324b1e7c4ce6514564e