### PR TITLE
Support per-purchase seat expirations and aggregate active seats

### DIFF
--- a/db/migrations/000104_business_seat_purchase_expiration.down.sql
+++ b/db/migrations/000104_business_seat_purchase_expiration.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE business_seat_purchases
+    DROP COLUMN expires_at;

--- a/db/migrations/000104_business_seat_purchase_expiration.up.sql
+++ b/db/migrations/000104_business_seat_purchase_expiration.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE business_seat_purchases
+    ADD COLUMN expires_at DATETIME NULL DEFAULT NULL AFTER payload_json;
+
+UPDATE business_seat_purchases p
+LEFT JOIN business_accounts a ON a.business_user_id = p.business_user_id
+SET p.expires_at = COALESCE(a.seats_expires_at, DATE_ADD(p.created_at, INTERVAL 30 DAY))
+WHERE p.expires_at IS NULL;
+
+ALTER TABLE business_seat_purchases
+    MODIFY expires_at DATETIME NOT NULL;

--- a/docs/business_accounts_ru.md
+++ b/docs/business_accounts_ru.md
@@ -19,8 +19,9 @@
 Источники истины (используются напрямую в репозиториях):
 
 - `business_accounts` — агрегированные поля `seats_total`, `seats_used`,
-  `status` (`active`/`suspended`).
-- `business_seat_purchases` — история покупок мест.
+  `status` (`active`/`suspended`) и максимальный срок действия.
+- `business_seat_purchases` — история покупок мест с собственным сроком действия
+  (`expires_at`); активные записи суммируются в `seats_total`.
 - `business_workers` — исполнители, связаны с `users` и бизнесом;
   содержит `login`, `chat_id`, `status`.
 
@@ -32,8 +33,8 @@
 1. Валидирует, что `seats > 0`.
 2. Получает или создаёт `business_accounts` для пользователя.
 3. Сохраняет покупку в `business_seat_purchases` с суммой `seats*1000`, если
-   `amount` не передан явно.
-4. Увеличивает `seats_total` и активирует аккаунт.
+   `amount` не передан явно, и сроком действия `expires_at`.
+4. Пересчитывает `seats_total` как сумму активных покупок и обновляет агрегаты.
 5. Присваивает пользователю роль `business` (в таблице `users`).
 
 Пример запроса:

--- a/internal/models/business.go
+++ b/internal/models/business.go
@@ -41,6 +41,7 @@ type BusinessSeatPurchase struct {
 	State          *string    `json:"state,omitempty"`
 	ProviderTxnID  *string    `json:"provider_txn_id,omitempty"`
 	PayloadJSON    any        `json:"payload_json,omitempty"`
+	ExpiresAt      *time.Time `json:"expires_at,omitempty"`
 	CreatedAt      time.Time  `json:"created_at"`
 	UpdatedAt      *time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
### Motivation
- Business seat purchases must be additive and have independent expirations so buying 100 seats and later 5 seats yields 105 active seats until each purchase expires.

### Description
- Add `ExpiresAt` to `BusinessSeatPurchase` and a migration to store per-purchase expiration timestamps and backfill existing rows (`db/migrations/000104_business_seat_purchase_expiration.*`).
- Persist `expires_at` when saving a purchase and set it in `BusinessService.PurchaseSeats` using the requested or default duration.
- Replace single-aggregate seat write with an aggregation flow: add `getActiveSeatSummary` and `RefreshSeatSummary` in `BusinessRepository`, and use them from `GetAccountByUserID` and after purchases to compute `seats_total` as the sum of non-expired purchases.
- Adjust account normalization logic in `BusinessService.normalizeAccount` and update `SaveSeatPurchase`/`GetAccountByUserID` to keep `seats_used` bounded by the aggregated `seats_total`.
- Update documentation `docs/business_accounts_ru.md` to describe per-purchase expirations and the new aggregation behavior.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735ed581f88324a6e55eb966a588e9)