### PR TITLE
Escape reserved SQL identifiers in rent and rent_ad UPDATE queries

### DIFF
--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -312,7 +312,7 @@ func (r *RentAdRepository) UpdateRentAd(ctx context.Context, work models.RentAd)
 	query := `
     UPDATE rent_ad
     SET name = ?, address = ?, price = ?, price_to = ?, negotiable = ?, hide_phone = ?, user_id = ?, city_id = ?, images = ?, videos = ?, category_id = ?, subcategory_id = ?,
-        work_time_from = ?, work_time_to = ?, description = ?, condition = ?, delivery = ?, avg_rating = ?, top = ?, liked = ?, status = ?, rent_type = ?, deposit = ?, latitude = ?, longitude = ?, order_date = ?, order_time = ?, updated_at = ?
+        work_time_from = ?, work_time_to = ?, description = ?, `condition` = ?, delivery = ?, avg_rating = ?, `top` = ?, liked = ?, status = ?, rent_type = ?, deposit = ?, latitude = ?, longitude = ?, order_date = ?, order_time = ?, updated_at = ?
     WHERE id = ?
 `
 	imagesJSON, err := json.Marshal(work.Images)

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -276,7 +276,7 @@ func (r *RentRepository) UpdateRent(ctx context.Context, work models.Rent) (mode
 	query := `
 UPDATE rent
 SET name = ?, address = ?, price = ?, price_to = ?, user_id = ?, city_id = ?, images = ?, videos = ?, category_id = ?, subcategory_id = ?,
-    work_time_from = ?, work_time_to = ?, description = ?, condition = ?, delivery = ?, avg_rating = ?, top = ?, negotiable = ?, hide_phone = ?, liked = ?, status = ?, rent_type = ?, deposit = ?, latitude = ?, longitude = ?, updated_at = ?
+    work_time_from = ?, work_time_to = ?, description = ?, `condition` = ?, delivery = ?, avg_rating = ?, `top` = ?, negotiable = ?, hide_phone = ?, liked = ?, status = ?, rent_type = ?, deposit = ?, latitude = ?, longitude = ?, updated_at = ?
 WHERE id = ?
 `
 	imagesJSON, err := json.Marshal(work.Images)


### PR DESCRIPTION
### Motivation
- Fix MariaDB syntax errors when updating rent records caused by unquoted reserved column names `condition` and `top` in UPDATE statements.

### Description
- Backtick-escaped the reserved identifiers in the UPDATE queries in `internal/repositories/rent_repository.go` and `internal/repositories/rent_ad_repository.go` by changing `condition` -> `` `condition` `` and `top` -> `` `top` ``.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736e413b848324ba49893f7787e9a1)