### PR TITLE
Allow backtick-escaped identifiers in rent and rent_ad UPDATE queries

### DIFF
--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -309,12 +309,10 @@ func (r *RentAdRepository) GetRentAdByIDWithCity(ctx context.Context, id int, us
 }
 
 func (r *RentAdRepository) UpdateRentAd(ctx context.Context, work models.RentAd) (models.RentAd, error) {
-	query := `
-    UPDATE rent_ad
-    SET name = ?, address = ?, price = ?, price_to = ?, negotiable = ?, hide_phone = ?, user_id = ?, city_id = ?, images = ?, videos = ?, category_id = ?, subcategory_id = ?,
-        work_time_from = ?, work_time_to = ?, description = ?, condition = ?, delivery = ?, avg_rating = ?, top = ?, liked = ?, status = ?, rent_type = ?, deposit = ?, latitude = ?, longitude = ?, order_date = ?, order_time = ?, updated_at = ?
-    WHERE id = ?
-`
+	query := "UPDATE rent_ad " +
+		"SET name = ?, address = ?, price = ?, price_to = ?, negotiable = ?, hide_phone = ?, user_id = ?, city_id = ?, images = ?, videos = ?, category_id = ?, subcategory_id = ?, " +
+		"work_time_from = ?, work_time_to = ?, description = ?, `condition` = ?, delivery = ?, avg_rating = ?, `top` = ?, liked = ?, status = ?, rent_type = ?, deposit = ?, latitude = ?, longitude = ?, order_date = ?, order_time = ?, updated_at = ? " +
+		"WHERE id = ?"
 	imagesJSON, err := json.Marshal(work.Images)
 	if err != nil {
 		return models.RentAd{}, fmt.Errorf("failed to marshal images: %w", err)

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -273,12 +273,10 @@ func (r *RentRepository) GetRentByIDWithCity(ctx context.Context, id int, userID
 }
 
 func (r *RentRepository) UpdateRent(ctx context.Context, work models.Rent) (models.Rent, error) {
-	query := `
-UPDATE rent
-SET name = ?, address = ?, price = ?, price_to = ?, user_id = ?, city_id = ?, images = ?, videos = ?, category_id = ?, subcategory_id = ?,
-    work_time_from = ?, work_time_to = ?, description = ?, condition = ?, delivery = ?, avg_rating = ?, top = ?, negotiable = ?, hide_phone = ?, liked = ?, status = ?, rent_type = ?, deposit = ?, latitude = ?, longitude = ?, updated_at = ?
-WHERE id = ?
-`
+	query := "UPDATE rent " +
+		"SET name = ?, address = ?, price = ?, price_to = ?, user_id = ?, city_id = ?, images = ?, videos = ?, category_id = ?, subcategory_id = ?, " +
+		"work_time_from = ?, work_time_to = ?, description = ?, `condition` = ?, delivery = ?, avg_rating = ?, `top` = ?, negotiable = ?, hide_phone = ?, liked = ?, status = ?, rent_type = ?, deposit = ?, latitude = ?, longitude = ?, updated_at = ? " +
+		"WHERE id = ?"
 	imagesJSON, err := json.Marshal(work.Images)
 	if err != nil {
 		return models.Rent{}, fmt.Errorf("failed to marshal images: %w", err)


### PR DESCRIPTION
### Motivation
- Fix Go compile errors caused by including backtick-escaped SQL identifiers inside raw string literals which produced `syntax error: unexpected name condition` during parsing.  
- Ensure reserved column names used in MariaDB (`condition`, `top`) remain quoted in UPDATE statements so SQL executes correctly.

### Description
- Replace multi-line raw string literals with concatenated Go string literals for the UPDATE query in `internal/repositories/rent_repository.go` so backtick-escaped identifiers like `` `condition` `` and `` `top` `` compile cleanly.  
- Apply the same change to the UPDATE query in `internal/repositories/rent_ad_repository.go` to keep `` `condition` `` and `` `top` `` quoted while avoiding raw string parsing issues.  
- Keep the rest of the query argument ordering and marshaling logic unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736e413b848324ba49893f7787e9a1)