### PR TITLE
Fix iOS business seat purchase duration handling

### DIFF
--- a/internal/handlers/iap_handler.go
+++ b/internal/handlers/iap_handler.go
@@ -283,9 +283,13 @@ func (h *IAPHandler) applyTarget(ctx context.Context, userID int, target models.
 		}
 		provider := "apple_iap"
 		state := "paid"
+		var durationDays *int
+		if target.DurationDays > 0 {
+			durationDays = &target.DurationDays
+		}
 		req := services.PurchaseRequest{
 			Seats:         target.Seats,
-			DurationDays:  &target.DurationDays,
+			DurationDays:  durationDays,
 			Provider:      &provider,
 			ProviderTxnID: &txn.TransactionID,
 			State:         &state,


### PR DESCRIPTION
### Motivation
- Prevent sending a zero `duration_days` value from Apple IAP flow when applying `business` entitlements, which could cause incorrect behavior in seat purchases for iOS.

### Description
- Update `internal/handlers/iap_handler.go` to only set `DurationDays` in `services.PurchaseRequest` when `target.DurationDays > 0` by using a `*int` and passing `nil` otherwise.

### Testing
- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69737149c054832487980cceb0890f80)