### PR TITLE
Expand Airbapay history to include iOS and Google Play transactions

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -179,6 +179,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	// Repositories\
 	invoiceRepo := repositories.NewInvoiceRepo(db)
 	iapRepo := repositories.NewIAPRepository(db)
+	googleIapRepo := repositories.NewGoogleIAPRepository(db)
 	userRepo := repositories.UserRepository{DB: db}
 	serviceRepo := repositories.ServiceRepository{DB: db}
 	categoryRepo := repositories.CategoryRepository{DB: db}
@@ -385,7 +386,7 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	adResponseHandler := &handlers.AdResponseHandler{Service: adResponseService}
 	adFavoriteHandler := &handlers.AdFavoriteHandler{Service: adFavoriteService}
 	subscriptionHandler := &handlers.SubscriptionHandler{Service: subscriptionService}
-	airbapayHandler := handlers.NewAirbapayHandler(airbapayService, invoiceRepo, &subscriptionRepo)
+	airbapayHandler := handlers.NewAirbapayHandler(airbapayService, invoiceRepo, &subscriptionRepo, iapRepo, googleIapRepo)
 	airbapayHandler.TopService = topService
 	airbapayHandler.BusinessService = businessService
 	locationHandler := &handlers.LocationHandler{Service: locationService}
@@ -503,8 +504,6 @@ func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	} else {
 		infoLog.Println("Google Play IAP: disabled (missing GOOGLE_PLAY_PACKAGE_NAME and/or GOOGLE_PLAY_SERVICE_ACCOUNT_JSON/GOOGLE_PLAY_SERVICE_ACCOUNT_FILE)")
 	}
-
-	googleIapRepo := repositories.NewGoogleIAPRepository(db)
 
 	googleIapHandler := handlers.NewGoogleIAPHandler(
 		googleSvc,

--- a/internal/models/payment_history.go
+++ b/internal/models/payment_history.go
@@ -1,0 +1,29 @@
+package models
+
+import "time"
+
+type PaymentHistoryItem struct {
+	Provider          string            `json:"provider"`
+	CreatedAt         time.Time         `json:"created_at"`
+	Invoice           *Invoice          `json:"invoice,omitempty"`
+	AppleTransaction  *AppleIAPHistory  `json:"apple_transaction,omitempty"`
+	GoogleTransaction *GoogleIAPHistory `json:"google_transaction,omitempty"`
+}
+
+type AppleIAPHistory struct {
+	TransactionID         string    `json:"transaction_id"`
+	OriginalTransactionID string    `json:"original_transaction_id"`
+	ProductID             string    `json:"product_id"`
+	Environment           string    `json:"environment"`
+	BundleID              string    `json:"bundle_id"`
+	CreatedAt             time.Time `json:"created_at"`
+}
+
+type GoogleIAPHistory struct {
+	PurchaseToken string    `json:"purchase_token"`
+	OrderID       string    `json:"order_id"`
+	ProductID     string    `json:"product_id"`
+	PackageName   string    `json:"package_name"`
+	Kind          string    `json:"kind"`
+	CreatedAt     time.Time `json:"created_at"`
+}

--- a/internal/repositories/iap_repository.go
+++ b/internal/repositories/iap_repository.go
@@ -155,3 +155,31 @@ FROM apple_iap_transactions WHERE user_id = ? ORDER BY created_at DESC LIMIT 1`,
 	txn.Raw = raw
 	return txn, nil
 }
+
+func (r *IAPRepository) ListByUser(ctx context.Context, userID int) ([]models.AppleIAPHistory, error) {
+	if err := r.ensureSchema(ctx); err != nil {
+		return nil, err
+	}
+	rows, err := r.DB.QueryContext(ctx, `
+SELECT transaction_id, original_transaction_id, product_id, environment, bundle_id, created_at
+FROM apple_iap_transactions
+WHERE user_id = ?
+ORDER BY created_at DESC`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []models.AppleIAPHistory
+	for rows.Next() {
+		var item models.AppleIAPHistory
+		if err := rows.Scan(&item.TransactionID, &item.OriginalTransactionID, &item.ProductID, &item.Environment, &item.BundleID, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}


### PR DESCRIPTION
### Motivation
- The existing `/airbapay/history/:user_id` endpoint returned only Airbapay invoices and should show a unified chronological payment history across Airbapay, iOS (Apple IAP) and Google Play transactions. 
- Provide a single response that clients can display sorted by time (newest first) and indicate the provider for each record.

### Description
- Added a shared history model `PaymentHistoryItem` and provider-specific history structs in `internal/models/payment_history.go` to represent invoices, Apple IAP and Google Play rows.
- Implemented `ListByUser` on `IAPRepository` (`internal/repositories/iap_repository.go`) and `GoogleIAPRepository` (`internal/repositories/iap_google_repository.go`) to fetch per-user IAP transaction rows ordered by `created_at`.
- Updated `AirbapayHandler` (`internal/handlers/airbapay_handler.go`) to accept IAP repositories, aggregate Airbapay invoices, Apple and Google transactions into a single `[]PaymentHistoryItem`, sort by `created_at` descending and return that JSON from `GetHistory`.
- Wired the new repositories into the application by updating `cmd/initializer.go` to construct `NewGoogleIAPRepository` and pass both IAP repos into `NewAirbapayHandler`.

### Testing
- Ran code formatting with `gofmt` on modified files which completed successfully.
- No automated unit or integration tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766513e55c8324b67d3681854de4d9)