### PR TITLE
Allow business roles on taxi and courier routes

### DIFF
--- a/cmd/middleware.go
+++ b/cmd/middleware.go
@@ -108,7 +108,7 @@ func (app *application) JWTMiddleware(next http.Handler, requiredRoles ...string
 			case "client":
 				return claims.Role == "client" || claims.Role == "admin"
 			case "worker":
-				return claims.Role == "worker" || claims.Role == "admin" || claims.Role == "business_worker"
+				return claims.Role == "worker" || claims.Role == "admin" || claims.Role == "business_worker" || claims.Role == "business"
 			case "business":
 				return claims.Role == "business" || claims.Role == "admin"
 			case "business_worker":

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -77,6 +77,10 @@ func (app *application) withTaxiRoleHeaders(next http.Handler) http.Handler {
 		case "client":
 			r = r.Clone(r.Context())
 			r.Header.Set("X-Passenger-ID", fmt.Sprintf("%d", id))
+		case "business", "business_worker":
+			r = r.Clone(r.Context())
+			r.Header.Set("X-Driver-ID", fmt.Sprintf("%d", id))
+			r.Header.Set("X-Passenger-ID", fmt.Sprintf("%d", id))
 		case "admin":
 			// admins can observe without impersonation
 		default:
@@ -97,6 +101,10 @@ func (app *application) withCourierRoleHeaders(next http.Handler) http.Handler {
 			r.Header.Set("X-Courier-ID", fmt.Sprintf("%d", id))
 		case "client":
 			r = r.Clone(r.Context())
+			r.Header.Set("X-Sender-ID", fmt.Sprintf("%d", id))
+		case "business", "business_worker":
+			r = r.Clone(r.Context())
+			r.Header.Set("X-Courier-ID", fmt.Sprintf("%d", id))
 			r.Header.Set("X-Sender-ID", fmt.Sprintf("%d", id))
 		case "admin":
 			// admins can read without impersonation


### PR DESCRIPTION
### Motivation
- Business accounts should be able to access taxi and courier endpoints the same way `business_worker` can so they can act as both passenger/sender and driver/courier.

### Description
- Permit `business` role to satisfy `worker` checks in the JWT middleware by updating `roleAllowed` in `cmd/middleware.go` to accept `business` for `worker`-protected routes.
- Map `business` and `business_worker` roles to both passenger/driver headers in taxi middleware by updating `withTaxiRoleHeaders` in `cmd/routes.go` to set `X-Driver-ID` and `X-Passenger-ID` for those roles.
- Map `business` and `business_worker` roles to both sender/courier headers in courier middleware by updating `withCourierRoleHeaders` in `cmd/routes.go` to set `X-Courier-ID` and `X-Sender-ID` for those roles.
- Changes applied to `cmd/middleware.go` and `cmd/routes.go`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69769142176c83248a50f6cfced89483)