### PR TITLE
Include user info in favorites responses

### DIFF
--- a/internal/models/ad_favorites.go
+++ b/internal/models/ad_favorites.go
@@ -5,21 +5,30 @@ import (
 )
 
 type AdFavorite struct {
-	ID         int       `json:"id"`
-	UserID     int       `json:"user_id"`
-	AdID       int       `json:"ad_id"`
-	CityID     int       `json:"city_id"`
-	CityName   string    `json:"city_name"`
-	Name       string    `json:"name"`
-	Address    string    `json:"address"`
-	Price      *float64  `json:"price"`
-	PriceTo    *float64  `json:"price_to"`
-	OnSite     bool      `json:"on_site"`
-	Negotiable bool      `json:"negotiable"`
-	HidePhone  bool      `json:"hide_phone"`
-	ImagePath  *string   `json:"image_path,omitempty"`
-	OrderDate  *string   `json:"order_date,omitempty"`
-	OrderTime  *string   `json:"order_time,omitempty"`
-	Status     string    `json:"status"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID         int      `json:"id"`
+	UserID     int      `json:"user_id"`
+	AdID       int      `json:"ad_id"`
+	CityID     int      `json:"city_id"`
+	CityName   string   `json:"city_name"`
+	Name       string   `json:"name"`
+	Address    string   `json:"address"`
+	Price      *float64 `json:"price"`
+	PriceTo    *float64 `json:"price_to"`
+	OnSite     bool     `json:"on_site"`
+	Negotiable bool     `json:"negotiable"`
+	HidePhone  bool     `json:"hide_phone"`
+	User       struct {
+		ID           int     `json:"id"`
+		Name         string  `json:"name"`
+		Surname      string  `json:"surname"`
+		Phone        string  `json:"phone"`
+		ReviewRating float64 `json:"review_rating"`
+		ReviewsCount int     `json:"reviews_count"`
+		AvatarPath   *string `json:"avatar_path,omitempty"`
+	} `json:"user"`
+	ImagePath *string   `json:"image_path,omitempty"`
+	OrderDate *string   `json:"order_date,omitempty"`
+	OrderTime *string   `json:"order_time,omitempty"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/internal/models/rent_ad_favorites.go
+++ b/internal/models/rent_ad_favorites.go
@@ -5,22 +5,31 @@ import (
 )
 
 type RentAdFavorite struct {
-	ID           int       `json:"id"`
-	UserID       int       `json:"user_id"`
-	RentAdID     int       `json:"rent_ad_id"`
-	CityID       int       `json:"city_id"`
-	CityName     string    `json:"city_name"`
-	Name         string    `json:"name"`
-	Address      string    `json:"address"`
-	Price        *float64  `json:"price"`
-	PriceTo      *float64  `json:"price_to"`
-	WorkTimeFrom string    `json:"work_time_from"`
-	WorkTimeTo   string    `json:"work_time_to"`
-	Negotiable   bool      `json:"negotiable"`
-	HidePhone    bool      `json:"hide_phone"`
-	ImagePath    *string   `json:"image_path,omitempty"`
-	OrderDate    *string   `json:"order_date,omitempty"`
-	OrderTime    *string   `json:"order_time,omitempty"`
-	Status       string    `json:"status"`
-	CreatedAt    time.Time `json:"created_at"`
+	ID           int      `json:"id"`
+	UserID       int      `json:"user_id"`
+	RentAdID     int      `json:"rent_ad_id"`
+	CityID       int      `json:"city_id"`
+	CityName     string   `json:"city_name"`
+	Name         string   `json:"name"`
+	Address      string   `json:"address"`
+	Price        *float64 `json:"price"`
+	PriceTo      *float64 `json:"price_to"`
+	WorkTimeFrom string   `json:"work_time_from"`
+	WorkTimeTo   string   `json:"work_time_to"`
+	Negotiable   bool     `json:"negotiable"`
+	HidePhone    bool     `json:"hide_phone"`
+	User         struct {
+		ID           int     `json:"id"`
+		Name         string  `json:"name"`
+		Surname      string  `json:"surname"`
+		Phone        string  `json:"phone"`
+		ReviewRating float64 `json:"review_rating"`
+		ReviewsCount int     `json:"reviews_count"`
+		AvatarPath   *string `json:"avatar_path,omitempty"`
+	} `json:"user"`
+	ImagePath *string   `json:"image_path,omitempty"`
+	OrderDate *string   `json:"order_date,omitempty"`
+	OrderTime *string   `json:"order_time,omitempty"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/internal/models/rent_favorites.go
+++ b/internal/models/rent_favorites.go
@@ -5,20 +5,29 @@ import (
 )
 
 type RentFavorite struct {
-	ID           int       `json:"id"`
-	UserID       int       `json:"user_id"`
-	RentID       int       `json:"rent_id"`
-	CityID       int       `json:"city_id"`
-	CityName     string    `json:"city_name"`
-	Name         string    `json:"name"`
-	Address      string    `json:"address"`
-	Price        *float64  `json:"price"`
-	PriceTo      *float64  `json:"price_to"`
-	WorkTimeFrom string    `json:"work_time_from"`
-	WorkTimeTo   string    `json:"work_time_to"`
-	Negotiable   bool      `json:"negotiable"`
-	HidePhone    bool      `json:"hide_phone"`
-	ImagePath    *string   `json:"image_path,omitempty"`
-	Status       string    `json:"status"`
-	CreatedAt    time.Time `json:"created_at"`
+	ID           int      `json:"id"`
+	UserID       int      `json:"user_id"`
+	RentID       int      `json:"rent_id"`
+	CityID       int      `json:"city_id"`
+	CityName     string   `json:"city_name"`
+	Name         string   `json:"name"`
+	Address      string   `json:"address"`
+	Price        *float64 `json:"price"`
+	PriceTo      *float64 `json:"price_to"`
+	WorkTimeFrom string   `json:"work_time_from"`
+	WorkTimeTo   string   `json:"work_time_to"`
+	Negotiable   bool     `json:"negotiable"`
+	HidePhone    bool     `json:"hide_phone"`
+	User         struct {
+		ID           int     `json:"id"`
+		Name         string  `json:"name"`
+		Surname      string  `json:"surname"`
+		Phone        string  `json:"phone"`
+		ReviewRating float64 `json:"review_rating"`
+		ReviewsCount int     `json:"reviews_count"`
+		AvatarPath   *string `json:"avatar_path,omitempty"`
+	} `json:"user"`
+	ImagePath *string   `json:"image_path,omitempty"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/internal/models/service_favorite.go
+++ b/internal/models/service_favorite.go
@@ -5,19 +5,28 @@ import (
 )
 
 type ServiceFavorite struct {
-	ID         int       `json:"id"`
-	UserID     int       `json:"user_id"`
-	ServiceID  int       `json:"service_id"`
-	CityID     int       `json:"city_id"`
-	CityName   string    `json:"city_name"`
-	Name       string    `json:"name"`
-	Address    string    `json:"address"`
-	Price      *float64  `json:"price"`
-	PriceTo    *float64  `json:"price_to"`
-	OnSite     bool      `json:"on_site"`
-	Negotiable bool      `json:"negotiable"`
-	HidePhone  bool      `json:"hide_phone"`
-	ImagePath  *string   `json:"image_path,omitempty"`
-	Status     string    `json:"status"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID         int      `json:"id"`
+	UserID     int      `json:"user_id"`
+	ServiceID  int      `json:"service_id"`
+	CityID     int      `json:"city_id"`
+	CityName   string   `json:"city_name"`
+	Name       string   `json:"name"`
+	Address    string   `json:"address"`
+	Price      *float64 `json:"price"`
+	PriceTo    *float64 `json:"price_to"`
+	OnSite     bool     `json:"on_site"`
+	Negotiable bool     `json:"negotiable"`
+	HidePhone  bool     `json:"hide_phone"`
+	User       struct {
+		ID           int     `json:"id"`
+		Name         string  `json:"name"`
+		Surname      string  `json:"surname"`
+		Phone        string  `json:"phone"`
+		ReviewRating float64 `json:"review_rating"`
+		ReviewsCount int     `json:"reviews_count"`
+		AvatarPath   *string `json:"avatar_path,omitempty"`
+	} `json:"user"`
+	ImagePath *string   `json:"image_path,omitempty"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/internal/models/work_ad_favorites.go
+++ b/internal/models/work_ad_favorites.go
@@ -5,18 +5,27 @@ import (
 )
 
 type WorkAdFavorite struct {
-	ID         int       `json:"id"`
-	UserID     int       `json:"user_id"`
-	WorkAdID   int       `json:"work_ad_id"`
-	CityID     int       `json:"city_id"`
-	CityName   string    `json:"city_name"`
-	Name       string    `json:"name"`
-	Address    string    `json:"address"`
-	Price      *float64  `json:"price"`
-	PriceTo    *float64  `json:"price_to"`
-	Negotiable bool      `json:"negotiable"`
-	HidePhone  bool      `json:"hide_phone"`
-	ImagePath  *string   `json:"image_path,omitempty"`
-	Status     string    `json:"status"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID         int      `json:"id"`
+	UserID     int      `json:"user_id"`
+	WorkAdID   int      `json:"work_ad_id"`
+	CityID     int      `json:"city_id"`
+	CityName   string   `json:"city_name"`
+	Name       string   `json:"name"`
+	Address    string   `json:"address"`
+	Price      *float64 `json:"price"`
+	PriceTo    *float64 `json:"price_to"`
+	Negotiable bool     `json:"negotiable"`
+	HidePhone  bool     `json:"hide_phone"`
+	User       struct {
+		ID           int     `json:"id"`
+		Name         string  `json:"name"`
+		Surname      string  `json:"surname"`
+		Phone        string  `json:"phone"`
+		ReviewRating float64 `json:"review_rating"`
+		ReviewsCount int     `json:"reviews_count"`
+		AvatarPath   *string `json:"avatar_path,omitempty"`
+	} `json:"user"`
+	ImagePath *string   `json:"image_path,omitempty"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/internal/models/work_favorites.go
+++ b/internal/models/work_favorites.go
@@ -5,18 +5,27 @@ import (
 )
 
 type WorkFavorite struct {
-	ID         int       `json:"id"`
-	UserID     int       `json:"user_id"`
-	WorkID     int       `json:"work_id"`
-	CityID     int       `json:"city_id"`
-	CityName   string    `json:"city_name"`
-	Name       string    `json:"name"`
-	Address    string    `json:"address"`
-	Price      *float64  `json:"price"`
-	PriceTo    *float64  `json:"price_to"`
-	Negotiable bool      `json:"negotiable"`
-	HidePhone  bool      `json:"hide_phone"`
-	ImagePath  *string   `json:"image_path,omitempty"`
-	Status     string    `json:"status"`
-	CreatedAt  time.Time `json:"created_at"`
+	ID         int      `json:"id"`
+	UserID     int      `json:"user_id"`
+	WorkID     int      `json:"work_id"`
+	CityID     int      `json:"city_id"`
+	CityName   string   `json:"city_name"`
+	Name       string   `json:"name"`
+	Address    string   `json:"address"`
+	Price      *float64 `json:"price"`
+	PriceTo    *float64 `json:"price_to"`
+	Negotiable bool     `json:"negotiable"`
+	HidePhone  bool     `json:"hide_phone"`
+	User       struct {
+		ID           int     `json:"id"`
+		Name         string  `json:"name"`
+		Surname      string  `json:"surname"`
+		Phone        string  `json:"phone"`
+		ReviewRating float64 `json:"review_rating"`
+		ReviewsCount int     `json:"reviews_count"`
+		AvatarPath   *string `json:"avatar_path,omitempty"`
+	} `json:"user"`
+	ImagePath *string   `json:"image_path,omitempty"`
+	Status    string    `json:"status"`
+	CreatedAt time.Time `json:"created_at"`
 }


### PR DESCRIPTION
### Motivation
- Provide caller/frontend with author metadata for favorite items so UIs can show the user who published each favorited entity and associated ratings/counts.
- Populate per-user `reviews_count` so consumers can display an aggregated reviews number without extra calls.

### Description
- Added a `user` embedded struct (id, name, surname, phone, review_rating, reviews_count, avatar_path) to favorites response models for service, ad, work, work_ad, rent, and rent_ad.
- Updated favorites repository queries to `JOIN users` and select user fields, mapped the new columns into the favorites models, and updated scanning order accordingly.
- For each favorite result, populated `user.reviews_count` by calling `getUserTotalReviews(ctx, db, userID)` after scanning the row.
- Ran `gofmt` across modified files to normalize formatting.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977541fdda48324a8db35df0b9c8ee0)