### PR TITLE
Fix city_name in user-scoped item queries

### DIFF
--- a/internal/repositories/ad_repository.go
+++ b/internal/repositories/ad_repository.go
@@ -1047,7 +1047,7 @@ CASE WHEN sr.id IS NOT NULL THEN '1' ELSE '0' END AS responded
 func (r *AdRepository) GetAdByAdIDAndUserID(ctx context.Context, adID int, userID int) (models.Ad, error) {
 	query := `
     SELECT
-            s.id, s.name, s.address, s.on_site, s.price, s.price_to, s.negotiable, s.hide_phone, s.user_id, s.city_id,
+            s.id, s.name, s.address, s.on_site, s.price, s.price_to, s.negotiable, s.hide_phone, s.user_id, s.city_id, city.name,
             u.id, u.name, u.surname, u.review_rating, u.avatar_path,
               CASE WHEN sr.id IS NOT NULL THEN u.phone ELSE '' END AS phone,
                s.images, s.videos, s.category_id, c.name,
@@ -1058,6 +1058,7 @@ func (r *AdRepository) GetAdByAdIDAndUserID(ctx context.Context, adID int, userI
                s.latitude, s.longitude, s.order_date, s.order_time, s.status, s.created_at, s.updated_at
    FROM ad s
                JOIN users u ON s.user_id = u.id
+               LEFT JOIN cities city ON s.city_id = city.id
                JOIN categories c ON s.category_id = c.id
                JOIN subcategories sub ON s.subcategory_id = sub.id
                LEFT JOIN ad_favorites sf ON sf.ad_id = s.id AND sf.user_id = ?
@@ -1075,7 +1076,7 @@ func (r *AdRepository) GetAdByAdIDAndUserID(ctx context.Context, adID int, userI
 	var likedStr, respondedStr string
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, adID).Scan(
-		&s.ID, &s.Name, &s.Address, &s.OnSite, &price, &priceTo, &s.Negotiable, &s.HidePhone, &s.UserID, &s.CityID,
+	&s.ID, &s.Name, &s.Address, &s.OnSite, &price, &priceTo, &s.Negotiable, &s.HidePhone, &s.UserID, &s.CityID, &s.CityName,
 		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath, &s.User.Phone,
 		&imagesJSON, &videosJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,

--- a/internal/repositories/rent_ad_repository.go
+++ b/internal/repositories/rent_ad_repository.go
@@ -1133,7 +1133,7 @@ func (r *RentAdRepository) GetFilteredRentsAdWithLikes(ctx context.Context, req 
 func (r *RentAdRepository) GetRentAdByRentIDAndUserID(ctx context.Context, rentAdID int, userID int) (models.RentAd, error) {
 	query := `
             SELECT
-                    s.id, s.name, s.address, s.price, s.price_to, s.user_id, s.city_id,
+                    s.id, s.name, s.address, s.price, s.price_to, s.user_id, s.city_id, city.name,
                     u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                       CASE WHEN s.hide_phone = 0 AND sr.id IS NOT NULL THEN u.phone ELSE '' END AS phone,
                        s.images, s.videos, s.category_id, c.name,
@@ -1144,6 +1144,7 @@ func (r *RentAdRepository) GetRentAdByRentIDAndUserID(ctx context.Context, rentA
                        s.order_date, s.order_time, s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
                FROM rent_ad s
                JOIN users u ON s.user_id = u.id
+               LEFT JOIN cities city ON s.city_id = city.id
                JOIN rent_categories c ON s.category_id = c.id
                JOIN rent_subcategories sub ON s.subcategory_id = sub.id
                LEFT JOIN rent_ad_favorites sf ON sf.rent_ad_id = s.id AND sf.user_id = ?
@@ -1162,7 +1163,7 @@ func (r *RentAdRepository) GetRentAdByRentIDAndUserID(ctx context.Context, rentA
 	var likedStr, respondedStr string
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, rentAdID).Scan(
-		&s.ID, &s.Name, &s.Address, &price, &priceTo, &s.UserID, &s.CityID,
+	&s.ID, &s.Name, &s.Address, &price, &priceTo, &s.UserID, &s.CityID, &s.CityName,
 		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath, &s.User.Phone,
 		&imagesJSON, &videosJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName,

--- a/internal/repositories/rent_repository.go
+++ b/internal/repositories/rent_repository.go
@@ -1062,7 +1062,7 @@ WHERE 1=1 AND s.status != 'archive'
 func (r *RentRepository) GetRentByRentIDAndUserID(ctx context.Context, rentID int, userID int) (models.Rent, error) {
 	query := `
     SELECT
-    s.id, s.name, s.address, s.price, s.price_to, s.negotiable, s.hide_phone, s.user_id, s.city_id,
+    s.id, s.name, s.address, s.price, s.price_to, s.negotiable, s.hide_phone, s.user_id, s.city_id, city.name,
     u.id, u.name, u.surname, u.review_rating, u.avatar_path,
       CASE WHEN s.hide_phone = 0 AND sr.id IS NOT NULL THEN u.phone ELSE '' END AS phone,
     s.images, s.videos, s.category_id, c.name,
@@ -1073,6 +1073,7 @@ func (r *RentRepository) GetRentByRentIDAndUserID(ctx context.Context, rentID in
        s.status, s.rent_type, s.deposit, s.latitude, s.longitude, s.created_at, s.updated_at
        FROM rent s
        JOIN users u ON s.user_id = u.id
+       LEFT JOIN cities city ON s.city_id = city.id
        JOIN rent_categories c ON s.category_id = c.id
        JOIN rent_subcategories sub ON s.subcategory_id = sub.id
        LEFT JOIN rent_favorites sf ON sf.rent_id = s.id AND sf.user_id = ?
@@ -1091,7 +1092,7 @@ func (r *RentRepository) GetRentByRentIDAndUserID(ctx context.Context, rentID in
 	var likedStr, respondedStr string
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, rentID).Scan(
-		&s.ID, &s.Name, &s.Address, &price, &priceTo, &s.Negotiable, &s.HidePhone, &s.UserID, &s.CityID,
+	&s.ID, &s.Name, &s.Address, &price, &priceTo, &s.Negotiable, &s.HidePhone, &s.UserID, &s.CityID, &s.CityName,
 		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath, &s.User.Phone,
 		&imagesJSON, &videosJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName, &s.SubcategoryNameKz, &s.WorkTimeFrom, &s.WorkTimeTo,

--- a/internal/repositories/service_repository.go
+++ b/internal/repositories/service_repository.go
@@ -961,7 +961,7 @@ WHERE 1=1 AND s.status != 'archive'
 func (r *ServiceRepository) GetServiceByServiceIDAndUserID(ctx context.Context, serviceID int, userID int) (models.Service, error) {
 	query := `
             SELECT
-                    s.id, s.name, s.address, s.on_site, s.price, s.price_to, s.user_id, s.city_id,
+                    s.id, s.name, s.address, s.on_site, s.price, s.price_to, s.user_id, s.city_id, city.name,
                     u.id, u.name, u.surname, u.review_rating, u.avatar_path,
                        CASE WHEN s.hide_phone = 0 AND sr.id IS NOT NULL THEN u.phone ELSE '' END AS phone,
                        s.images, s.videos, s.category_id, c.name,
@@ -972,6 +972,7 @@ func (r *ServiceRepository) GetServiceByServiceIDAndUserID(ctx context.Context, 
                        s.latitude, s.longitude, s.status, s.created_at, s.updated_at
                FROM service s
                JOIN users u ON s.user_id = u.id
+               LEFT JOIN cities city ON s.city_id = city.id
                JOIN categories c ON s.category_id = c.id
                JOIN subcategories sub ON s.subcategory_id = sub.id
                LEFT JOIN service_favorites sf ON sf.service_id = s.id AND sf.user_id = ?
@@ -988,7 +989,7 @@ func (r *ServiceRepository) GetServiceByServiceIDAndUserID(ctx context.Context, 
 	var price, priceTo sql.NullFloat64
 
 	err := r.DB.QueryRowContext(ctx, query, userID, userID, serviceID).Scan(
-		&s.ID, &s.Name, &s.Address, &s.OnSite, &price, &priceTo, &s.UserID, &s.CityID,
+	&s.ID, &s.Name, &s.Address, &s.OnSite, &price, &priceTo, &s.UserID, &s.CityID, &s.CityName,
 		&s.User.ID, &s.User.Name, &s.User.Surname, &s.User.ReviewRating, &s.User.AvatarPath, &s.User.Phone,
 		&imagesJSON, &videosJSON, &s.CategoryID, &s.CategoryName,
 		&s.SubcategoryID, &s.SubcategoryName, &s.SubcategoryNameKz,


### PR DESCRIPTION
### Motivation
- Ensure user-scoped GET endpoints return the human-readable `city_name` alongside `city_id` so API responses include consistent location info.
- The user-scoped lookup variants (where a user ID is provided) previously did not select the city name, causing the `city_name` field to be empty for those routes.

### Description
- Added `LEFT JOIN cities city ON s.city_id = city.id` and `city.name` to the SELECT lists for the user-scoped queries in `internal/repositories/ad_repository.go`, `internal/repositories/service_repository.go`, `internal/repositories/rent_repository.go`, and `internal/repositories/rent_ad_repository.go`.
- Updated the corresponding `QueryRowContext(...).Scan(...)` calls to scan `&s.CityName` so the model is populated for `GetAdByAdIDAndUserID`, `GetServiceByServiceIDAndUserID`, `GetRentByRentIDAndUserID`, and `GetRentAdByRentIDAndUserID`.
- Changes are limited to SQL selection and result scanning and do not alter other fields or business logic.
- Files modified: `internal/repositories/ad_repository.go`, `internal/repositories/service_repository.go`, `internal/repositories/rent_repository.go`, and `internal/repositories/rent_ad_repository.go`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697756a045408324a58abfb0fef195f3)